### PR TITLE
[fix] Fix error in case of missing translations

### DIFF
--- a/lib/Formbuilder/Lib/Form/Frontend/Builder.php
+++ b/lib/Formbuilder/Lib/Form/Frontend/Builder.php
@@ -354,16 +354,15 @@ class Builder {
     {
         $translationFile = FORMBUILDER_DATA_PATH . '/lang/form_' . $id . '_' . $locale . '.json';
 
-        $trans = NULL;
+        $trans = new \Zend_Translate_Adapter_Array( [ 'disableNotices' => TRUE ] );
 
         if ( file_exists( $translationFile ) )
         {
             $transConfig = new \Zend_Config_Json( $translationFile );
 
-            $trans = new \Zend_Translate_Adapter_Array(
-                $transConfig->toArray(),
-                $locale
-            );
+            if ($transConfig->count() > 0) {
+                $trans->addTranslation( [ 'content' => $transConfig->toArray(), 'locale' => $locale ] );
+            }
 
         }
 


### PR DESCRIPTION
In case of missing translations, this fix prevents generation of error: _The language 'it' has to be added before it can be used_.

![error](https://cloud.githubusercontent.com/assets/1744861/21934282/25bee552-d9a9-11e6-878a-f7eb1c6c944f.jpg)