### PR TITLE
Change composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dachcom-digital/pimcore-formbuilder",
+    "name": "dachcom-digital/formbuilder",
     "type": "pimcore-plugin",
     "license": "GPL-3.0+",
     "description": "Pimcore 4.0 Build Forms quickly and easily",


### PR DESCRIPTION
The name "dachcom-digital/pimcore-formbuilder" generates the directory `plugins/PimcoreFormbuilder`, but this plugin requires that the name is `plugins/Formbuilder`.