### PR TITLE
fix translation import during installation

### DIFF
--- a/src/FormBuilderBundle/Tool/Install.php
+++ b/src/FormBuilderBundle/Tool/Install.php
@@ -133,7 +133,7 @@ class Install extends AbstractInstaller
      */
     private function installTranslations()
     {
-        $csv = $this->installSourcesPath . '/translations/fronted.csv';
+        $csv = $this->installSourcesPath . '/translations/frontend.csv';
         $csvAdmin = $this->installSourcesPath . '/translations/admin.csv';
 
         Translation\Website::importTranslationsFromFile($csv, TRUE, Admin::getLanguages());


### PR DESCRIPTION
message from pimcore extension installer: 
Status: 400 | Bad Request
URL: /admin/extensionmanager/admin/install
Message: .../vendor/dachcom-digital/formbuilder/src/FormBuilderBundle/Tool/../Resources/install/translations/fronted.csv is not readable