### PR TITLE
Javascript error when the settings menu was disabled via Perspective

### DIFF
--- a/src/FormBuilderBundle/Resources/public/js/plugin.js
+++ b/src/FormBuilderBundle/Resources/public/js/plugin.js
@@ -37,7 +37,9 @@ pimcore.plugin.Formbuilder = Class.create(pimcore.plugin.admin, {
                     handler: this.openSettings.bind(this)
                 });
 
-                layoutToolbar.settingsMenu.add(formBuilderMenu);
+                if(layoutToolbar.settingsMenu) {
+                    layoutToolbar.settingsMenu.add(formBuilderMenu);
+                }
 
             }.bind(this)
         });


### PR DESCRIPTION
When you disable the settings menu via a perspective, there is Javascript error, because the JS object "layoutToolbar.settingsMenu" is not available. This pull request fixes the error.