### PR TITLE
TypeError: Cannot read property 'getItems' of null

### DIFF
--- a/src/FormBuilderBundle/Resources/public/js/comp/form.js
+++ b/src/FormBuilderBundle/Resources/public/js/comp/form.js
@@ -1014,12 +1014,9 @@ Formbuilder.comp.form = Class.create({
 
     importForm: function(importedFormData) {
 
-        this.parentPanel.getEditPanel().removeAll();
-
         this.formConfig = importedFormData.data.config;
         this.formFields = importedFormData.data.fields;
 
-        this.addLayout();
         this.initLayoutFields();
     },
 


### PR DESCRIPTION
When i want to import fields to a new form all input fields get added, but when everything all fields / config settings have been added the error `TypeError: Cannot read property 'getItems' of null` is thrown.

After this error it's not possible to change the fields or save the form.

Not sure if this is the best solution, but by disabling the recreation of the edit panel everything works well.