### PR TITLE
Constraint config is now passed with the valid constraints fixes #102

### DIFF
--- a/src/FormBuilderBundle/Validation/ConditionalLogic/Dispatcher/Module/Constraints.php
+++ b/src/FormBuilderBundle/Validation/ConditionalLogic/Dispatcher/Module/Constraints.php
@@ -94,12 +94,10 @@ class Constraints implements ModuleInterface
         $this->appliedConditions = $options['appliedConditions'];
 
         //add defaults
-        $constraints = [];
         $fieldConstraints = $this->field->getConstraints();
         $validConstraints = $this->checkConditionalLogicConstraints($fieldConstraints);
 
         $completeConstraintData = $this->appendConstraintsData($validConstraints);
-
 
         $returnContainer = $this->dataFactory->generate(ConstraintsData::class);
         $returnContainer->setData($completeConstraintData);
@@ -131,20 +129,25 @@ class Constraints implements ModuleInterface
 
             if ($returnStack->getActionType() === 'addConstraints') {
                 foreach ($returnStack->getData() as $constraint) {
-                    $defaultFieldConstraints[] = $constraint;
+                    $defaultFieldConstraints[] = ['type' => $constraint];
                 }
             } elseif ($returnStack->getActionType() === 'removeConstraints') {
                 if ($returnStack->getData() === 'all') {
                     $defaultFieldConstraints = [];
                 } else {
                     foreach ($returnStack->getData() as $constraint) {
-                        $defaultFieldConstraints = array_diff($defaultFieldConstraints, [$constraint]);
+                        $defaultFieldConstraints = array_filter($defaultFieldConstraints, function ($val) use ($constraint) {
+                            return $val['type'] !== $constraint;
+                        });
                     }
                 }
             }
         }
 
-        return array_unique($defaultFieldConstraints);
+        $tempArr = array_unique(array_column($defaultFieldConstraints, 'type'));
+        array_intersect_key($defaultFieldConstraints, $tempArr);
+
+        return $defaultFieldConstraints;
     }
 
     /**

--- a/src/FormBuilderBundle/Validation/ConditionalLogic/Dispatcher/Module/Constraints.php
+++ b/src/FormBuilderBundle/Validation/ConditionalLogic/Dispatcher/Module/Constraints.php
@@ -96,18 +96,9 @@ class Constraints implements ModuleInterface
         //add defaults
         $constraints = [];
         $fieldConstraints = $this->field->getConstraints();
-        foreach ($fieldConstraints as $constraint) {
-            $constraints[] = $constraint['type'];
-        }
+        $validConstraints = $this->checkConditionalLogicConstraints($fieldConstraints);
 
-        $validConstraints = $this->checkConditionalLogicConstraints($constraints);
-
-        $constraintData = [];
-        foreach ($validConstraints as $validConstraint) {
-            $constraintData[] = ['type' => $validConstraint];
-        }
-
-        $completeConstraintData = $this->appendConstraintsData($constraintData);
+        $completeConstraintData = $this->appendConstraintsData($validConstraints);
 
 
         $returnContainer = $this->dataFactory->generate(ConstraintsData::class);

--- a/src/FormBuilderBundle/Validation/ConditionalLogic/Dispatcher/Module/FormTypeClasses.php
+++ b/src/FormBuilderBundle/Validation/ConditionalLogic/Dispatcher/Module/FormTypeClasses.php
@@ -70,7 +70,7 @@ class FormTypeClasses implements ModuleInterface
 
     /**
      * @param $options
-     * @return array
+     * @return DataInterface
      */
     public function apply($options)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #102 

The bug was caused by the loop where only the type of the constraint is added to the `$constraintData` array and the config of the constraints is not.