### PR TITLE
Added setting for limiting the number of files to DynamicMultiFileType

### DIFF
--- a/src/FormBuilderBundle/Form/Type/DynamicMultiFileType.php
+++ b/src/FormBuilderBundle/Form/Type/DynamicMultiFileType.php
@@ -45,7 +45,8 @@ class DynamicMultiFileType extends AbstractType
                 'messages'           => $this->getInterfaceTranslations(),
                 'multiple'           => $options['multiple'] ? 1 : 0,
                 'max_file_size'      => is_numeric($options['max_file_size']) ? (int)$options['max_file_size'] * 1024 * 1024 : 0,
-                'allowed_extensions' => is_array($options['allowed_extensions']) ? $options['allowed_extensions'] : []
+                'allowed_extensions' => is_array($options['allowed_extensions']) ? $options['allowed_extensions'] : [],
+                'item_limit'         => is_numeric($options['item_limit']) ? (int)$options['item_limit'] : 0
             ]
         ]);
 
@@ -62,6 +63,7 @@ class DynamicMultiFileType extends AbstractType
         $resolver->setDefaults([
             'max_file_size'      => false,
             'allowed_extensions' => false,
+            'item_limit'         => false
         ]);
     }
 

--- a/src/FormBuilderBundle/Form/Type/DynamicMultiFileType.php
+++ b/src/FormBuilderBundle/Form/Type/DynamicMultiFileType.php
@@ -61,9 +61,9 @@ class DynamicMultiFileType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'max_file_size'      => false,
-            'allowed_extensions' => false,
-            'item_limit'         => false
+            'max_file_size'      => 0,
+            'allowed_extensions' => [],
+            'item_limit'         => 0
         ]);
     }
 

--- a/src/FormBuilderBundle/Resources/config/types/types.yml
+++ b/src/FormBuilderBundle/Resources/config/types/types.yml
@@ -254,6 +254,15 @@ form_builder:
                         display_group_id: attributes
                         type: label
                         label: 'form_builder_type_field.allowed_extensions_desc'
+                    options.item_limit:
+                        display_group_id: attributes
+                        type: textfield
+                        label: 'form_builder_type_field.item_limit'
+                        config: ~
+                    options.item_limit_label:
+                        display_group_id: attributes
+                        type: label
+                        label: 'form_builder_type_field.item_limit_desc'
                     options.max_file_size:
                         display_group_id: attributes
                         type: textfield

--- a/src/FormBuilderBundle/Resources/install/translations/admin.csv
+++ b/src/FormBuilderBundle/Resources/install/translations/admin.csv
@@ -82,6 +82,8 @@
 "form_builder_type_field.placeholder_desc","This option determines whether or not a special 'empty' option (e.g. 'Choose an option') will appear at the top of a select field. This option only applies if the multiple option is set to false. Leave empty for no default option.","Diese Option legt fest, ob eine spezielle 'leere' Option (z. B. 'Wählen Sie eine Option') am oberen Rand eines Auswahlfeldes erscheinen soll. Diese Option gilt nur, wenn die Option 'Mehrfach' nicht aktiv ist. Leer lassen für keine Standardoption."
 "form_builder_type_field.allowed_extensions","Allowed Extensions","Erlaubte Dateitypen"
 "form_builder_type_field.allowed_extensions_desc","Add some extensions and confirm with enter.","Fügen Sie erlaubte Dateierweiterungen hinzu und bestätigen Sie mit der Enter-Taste."
+"form_builder_type_field.item_limit","Item limit","Datei-Limit"
+"form_builder_type_field.item_limit_desc","The maximum number of files that can be uploaded. 0 = unlimited.","Die maximale Anzahl an Dateien welche hochgeladen werden darf. 0 = Kein Limit."
 "form_builder_type_field.max_file_size","Max File Size","Max. Dateigröße"
 "form_builder_type_field.max_file_size_desc","Max file size will be calculated in MB. Empty or Zero means no Limit!","Maximale Dateigröße wird in MB verarbeitet. Leer oder 0 bedeutet kein Limit!"
 "form_builder_type_field.date_seconds","Seconds","Sekunden"

--- a/src/FormBuilderBundle/Resources/public/js/frontend/legacy/formbuilder.js
+++ b/src/FormBuilderBundle/Resources/public/js/frontend/legacy/formbuilder.js
@@ -192,7 +192,8 @@ var formBuilder = (function () {
                         },
                         validation: {
                             sizeLimit: config.max_file_size,
-                            allowedExtensions: config.allowed_extensions
+                            allowedExtensions: config.allowed_extensions,
+                            itemLimit: config.item_limit
                         },
                         callbacks: {
                             onUpload : function() {
@@ -212,6 +213,8 @@ var formBuilder = (function () {
                             }
                         }
                     });
+                    console.log('item Limit (legacy):');
+                    console.log(config.item_limit);
 
                     $template.remove();
                 }

--- a/src/FormBuilderBundle/Resources/public/js/frontend/legacy/formbuilder.js
+++ b/src/FormBuilderBundle/Resources/public/js/frontend/legacy/formbuilder.js
@@ -213,8 +213,6 @@ var formBuilder = (function () {
                             }
                         }
                     });
-                    console.log('item Limit (legacy):');
-                    console.log(config.item_limit);
 
                     $template.remove();
                 }

--- a/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.core.form-builder.js
+++ b/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.core.form-builder.js
@@ -303,8 +303,6 @@
                         }
                     }
                 });
-                console.log('item Limit:');
-                console.log(config.item_limit);
 
                 $template.remove();
 

--- a/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.core.form-builder.js
+++ b/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.core.form-builder.js
@@ -281,7 +281,8 @@
                     },
                     validation: {
                         sizeLimit: config.max_file_size,
-                        allowedExtensions: config.allowed_extensions
+                        allowedExtensions: config.allowed_extensions,
+                        itemLimit: config.item_limit
                     },
                     callbacks: {
                         onUpload: function () {
@@ -302,6 +303,8 @@
                         }
                     }
                 });
+                console.log('item Limit:');
+                console.log(config.item_limit);
 
                 $template.remove();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Resolves tickets | #104 

Adds a new setting to the Dynamic MultiFile Field to set an item limit so users can only upload a certain number of files.