### PR TITLE
Fixing chunked fileupload, fixes issue #120

### DIFF
--- a/src/FormBuilderBundle/Stream/FileStream.php
+++ b/src/FormBuilderBundle/Stream/FileStream.php
@@ -18,6 +18,11 @@ use Pimcore\Model\Asset;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+/**
+ * Class FileStream
+ *
+ * @package FormBuilderBundle\Stream
+ */
 class FileStream
 {
     /**
@@ -144,9 +149,11 @@ class FileStream
 
         $target = fopen($targetPath, 'wb');
         for ($i = 0; $i < $totalParts; $i++) {
-            $chunk = fopen($targetFolder . DIRECTORY_SEPARATOR . $i, 'rb');
-            stream_copy_to_stream($chunk, $target);
-            fclose($chunk);
+            foreach ($this->fileLocator->getFilesFromChunkFolder($targetFolder . DIRECTORY_SEPARATOR . $i) as $chunkfile) {
+                $chunk = fopen($chunkfile->getPathname(), 'rb');
+                stream_copy_to_stream($chunk, $target);
+                fclose($chunk);
+            }
         }
 
         // Success

--- a/src/FormBuilderBundle/Tool/FileLocator.php
+++ b/src/FormBuilderBundle/Tool/FileLocator.php
@@ -79,6 +79,19 @@ class FileLocator
     }
 
     /**
+     * return content of $chunkDir as Finder-Object
+     *
+     * @param string $chunkDir
+     *
+     * @return Finder
+     */
+    public function getFilesFromChunkFolder(string $chunkDir)
+    {
+        $finder = new Finder();
+        return $finder->files()->in($chunkDir);
+    }
+
+    /**
      * @return string
      */
     public function getZipFolder()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | #120 

Issue was, that instead of opening chunkfiles, code tried to open the directories (containing the chunks), which lead to returning no bytes
