### PR TITLE
PHPDoc for Storage interfaces

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,10 +6,8 @@
 After every update you should check the pimcore extension manager. 
 Just click the "update" button to finish the bundle update.
 
-#### Update from Version 2.4.2 to Version 2.4.3
-- fixed [issue #120](https://github.com/dachcom-digital/pimcore-formbuilder/issues/120) Fileupload failed with bigger files up to 2.5 MB
-
 #### Update from Version 2.4.1 to Version 2.4.2
+- fixed [issue #120](https://github.com/dachcom-digital/pimcore-formbuilder/issues/120) Fileupload failed with bigger files up to 2.5 MB
 - implemented [PackageVersionTrait](https://github.com/pimcore/pimcore/blob/master/lib/Extension/Bundle/Traits/PackageVersionTrait.php)
 
 #### Update from Version 2.4.0 to Version 2.4.1

--- a/src/FormBuilderBundle/Storage/Form.php
+++ b/src/FormBuilderBundle/Storage/Form.php
@@ -106,6 +106,7 @@ class Form extends Model\AbstractModel implements FormInterface
     public static function getAll()
     {
         $list = new Form\Listing;
+
         return $list->getData();
     }
 
@@ -144,11 +145,11 @@ class Form extends Model\AbstractModel implements FormInterface
     }
 
     /**
-     * @param $newName
+     * @param string $newName
      *
      * @return bool
      */
-    public function rename($newName)
+    public function rename(string $newName)
     {
         $this->setName($newName);
         $this->save();
@@ -181,7 +182,7 @@ class Form extends Model\AbstractModel implements FormInterface
     }
 
     /**
-     * @return null
+     * @return int|null
      */
     public function getId()
     {
@@ -189,15 +190,15 @@ class Form extends Model\AbstractModel implements FormInterface
     }
 
     /**
-     * @param $name
+     * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
 
     /**
-     * @return null
+     * @return string
      */
     public function getName()
     {
@@ -205,7 +206,7 @@ class Form extends Model\AbstractModel implements FormInterface
     }
 
     /**
-     * @param $date
+     * @param mixed $date
      */
     public function setDate($date)
     {
@@ -213,7 +214,7 @@ class Form extends Model\AbstractModel implements FormInterface
     }
 
     /**
-     * @return null
+     * @return mixed
      */
     public function getDate()
     {
@@ -229,14 +230,15 @@ class Form extends Model\AbstractModel implements FormInterface
     }
 
     /**
-     * @param $config
+     * @param array $config
      *
      * @return $this
      */
-    public function setConfig($config)
+    public function setConfig(array $config)
     {
         $validConfig = array_intersect_key($config, array_flip(self::ALLOWED_FORM_KEYS));
         $this->config = $validConfig;
+
         return $this;
     }
 
@@ -249,25 +251,27 @@ class Form extends Model\AbstractModel implements FormInterface
     }
 
     /**
-     * @param $config
+     * @param array $config
      *
      * @return $this
      */
-    public function setConditionalLogic($config)
+    public function setConditionalLogic(array $config)
     {
         $this->conditionalLogic = $config;
+
         return $this;
     }
 
     /**
-     * @param       $name
-     * @param       $type
-     * @param       $options
-     * @param array $optional
+     * @param string $name
+     * @param string $type
+     * @param array  $options
+     * @param array  $optional
+     *
      * @return $this
      * @throws \Exception
      */
-    public function addDynamicField($name, $type, $options, $optional = [])
+    public function addDynamicField(string $name, string $type, array $options, array $optional = [])
     {
         if (in_array($name, Configuration::INVALID_FIELD_NAMES)) {
             throw new \Exception(sprintf('\'%s\' is a reserved form field name used by the form builder bundle and cannot be used.', $name));
@@ -284,11 +288,13 @@ class Form extends Model\AbstractModel implements FormInterface
 
         $dynamicField = new FormFieldDynamic($name, $type, $options, $optional, $update);
         $this->fields[$name] = $dynamicField;
+
         return $this;
     }
 
     /**
      * @param $name
+     *
      * @return $this
      * @throws \Exception
      */
@@ -325,11 +331,11 @@ class Form extends Model\AbstractModel implements FormInterface
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return array
      */
-    public function getFieldsByType($type)
+    public function getFieldsByType(string $type)
     {
         $fields = [];
 
@@ -343,25 +349,27 @@ class Form extends Model\AbstractModel implements FormInterface
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
-     * @return mixed
+     * @return FormField|null
      */
-    public function getField($name)
+    public function getField(string $name)
     {
         foreach ($this->fields as $field) {
             if ($field->getName() === $name) {
                 return $field;
             }
         }
+
+        return null;
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
-     * @return null
+     * @return string|null
      */
-    public function getFieldType($name)
+    public function getFieldType(string $name)
     {
         $field = $this->getField($name);
 
@@ -401,6 +409,7 @@ class Form extends Model\AbstractModel implements FormInterface
         }
 
         $data = $this->getData();
+
         return isset($data[$name]);
     }
 
@@ -417,14 +426,17 @@ class Form extends Model\AbstractModel implements FormInterface
      *
      * @param string $name
      *
-     * @return string|array
+     * @return string|array|null
      */
-    public function getFieldValue($name)
+    public function getFieldValue(string $name)
     {
         $array = $this->getData();
+
         if (isset($array[$name])) {
             return $array[$name];
         }
+
+        return null;
     }
 
 }

--- a/src/FormBuilderBundle/Storage/FormField.php
+++ b/src/FormBuilderBundle/Storage/FormField.php
@@ -24,7 +24,7 @@ class FormField implements FormFieldInterface
     /**
      * @var string
      */
-    private $display_name;
+    private $displayName;
 
     /**
      * @var string
@@ -82,9 +82,10 @@ class FormField implements FormFieldInterface
      *
      * @return FormField
      */
-    public function setOrder($order)
+    public function setOrder(int $order)
     {
         $this->order = $order;
+
         return $this;
     }
 
@@ -93,9 +94,10 @@ class FormField implements FormFieldInterface
      *
      * @return FormField
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
+
         return $this;
     }
 
@@ -112,9 +114,10 @@ class FormField implements FormFieldInterface
      *
      * @return FormField
      */
-    public function setDisplayName($name)
+    public function setDisplayName(string $name)
     {
-        $this->display_name = $name;
+        $this->displayName = $name;
+        
         return $this;
     }
 
@@ -123,7 +126,7 @@ class FormField implements FormFieldInterface
      */
     public function getDisplayName()
     {
-        return $this->display_name;
+        return $this->displayName;
     }
 
     /**
@@ -131,9 +134,10 @@ class FormField implements FormFieldInterface
      *
      * @return FormField
      */
-    public function setType($type)
+    public function setType(string $type)
     {
         $this->type = $type;
+
         return $this;
     }
 
@@ -156,7 +160,7 @@ class FormField implements FormFieldInterface
     /**
      * @param array $options
      */
-    public function setOptions($options = [])
+    public function setOptions(array $options = [])
     {
         $this->options = array_filter($options, function ($option) {
             return $option !== '';
@@ -174,7 +178,7 @@ class FormField implements FormFieldInterface
     /**
      * @param array $options
      */
-    public function setOptional($options = [])
+    public function setOptional(array $options = [])
     {
         if (!is_array($options)) {
             $options = [];
@@ -196,7 +200,7 @@ class FormField implements FormFieldInterface
     /**
      * @param array $constraints
      */
-    public function setConstraints($constraints = [])
+    public function setConstraints(array $constraints = [])
     {
         if (!is_array($constraints)) {
             $constraints = [];
@@ -225,6 +229,7 @@ class FormField implements FormFieldInterface
         }
 
         $removeKeys = ['translator', 'update'];
+
         return array_diff_key($array, array_flip($removeKeys));
     }
 }

--- a/src/FormBuilderBundle/Storage/FormFieldDynamicInterface.php
+++ b/src/FormBuilderBundle/Storage/FormFieldDynamicInterface.php
@@ -4,15 +4,33 @@ namespace FormBuilderBundle\Storage;
 
 interface FormFieldDynamicInterface
 {
+    /**
+     * @return string|false
+     */
     public function getName();
 
+    /**
+     * @return string
+     */
     public function getType();
 
+    /**
+     * @return string
+     */
     public function getOptions();
 
+    /**
+     * @return string
+     */
     public function getOptional();
 
+    /**
+     * @return int|mixed
+     */
     public function getOrder();
 
+    /**
+     * @return bool
+     */
     public function isUpdated();
 }

--- a/src/FormBuilderBundle/Storage/FormFieldInterface.php
+++ b/src/FormBuilderBundle/Storage/FormFieldInterface.php
@@ -6,38 +6,104 @@ use Pimcore\Translation\Translator;
 
 interface FormFieldInterface
 {
+    /**
+     * @param Translator $translator
+     *
+     * @return FormFieldInterface|void
+     */
     public function setTranslator(Translator $translator);
 
+    /**
+     * @return int
+     */
     public function getOrder();
 
-    public function setOrder($order);
+    /**
+     * @param int $order
+     *
+     * @return FormFieldInterface|void
+     */
+    public function setOrder(int $order);
 
-    public function setName($name);
+    /**
+     * @param string $name
+     *
+     * @return FormFieldInterface|void
+     */
+    public function setName(string $name);
 
+    /**
+     * @return string
+     */
     public function getName();
 
-    public function setDisplayName($name);
+    /**
+     * @param string $name
+     *
+     * @return FormFieldInterface|void
+     */
+    public function setDisplayName(string $name);
 
+    /**
+     * @return string
+     */
     public function getDisplayName();
 
-    public function setType($type);
+    /**
+     * @param string $type
+     *
+     * @return FormFieldInterface|void
+     */
+    public function setType(string $type);
 
+    /**
+     * @return string
+     */
     public function getType();
 
-    public function setOptions($options = []);
+    /**
+     * @param array $options
+     *
+     * @return FormFieldInterface|void
+     */
+    public function setOptions(array $options = []);
 
+    /**
+     * @return array
+     */
     public function getOptions();
 
-    public function setOptional($options = []);
+    /**
+     * @param array $options
+     *
+     * @return FormFieldInterface|void
+     */
+    public function setOptional(array $options = []);
 
+    /**
+     * @return array
+     */
     public function getOptional();
 
-    public function setConstraints($constraints = []);
+    /**
+     * @param array $constraints
+     *
+     * @return FormFieldInterface|void
+     */
+    public function setConstraints(array $constraints = []);
 
+    /**
+     * @return array
+     */
     public function getConstraints();
 
+    /**
+     * @return array
+     */
     public function toArray();
 
+    /**
+     * @return bool
+     */
     public function isUpdated();
-
 }

--- a/src/FormBuilderBundle/Storage/FormInterface.php
+++ b/src/FormBuilderBundle/Storage/FormInterface.php
@@ -18,7 +18,7 @@ interface FormInterface
      *
      * @return true
      */
-    public function rename($newName);
+    public function rename(string $newName);
 
     /**
      * @return mixed
@@ -35,7 +35,7 @@ interface FormInterface
      *
      * @return FormInterface|void
      */
-    public function setName($name);
+    public function setName(string $name);
 
     /**
      * @return string
@@ -91,7 +91,7 @@ interface FormInterface
      *
      * @return FormInterface|void
      */
-    public function addDynamicField($name, $type, $options, $optional = []);
+    public function addDynamicField(string $name, string $type, array $options, array $optional = []);
 
     /**
      * @param array $fields
@@ -122,14 +122,14 @@ interface FormInterface
     /**
      * @param string $name
      *
-     * @return string
+     * @return string|null
      */
     public function getFieldType(string $name);
 
     /**
      * @param string $name
      *
-     * @return string|array
+     * @return string|array|null
      */
     public function getFieldValue(string $name);
 }

--- a/src/FormBuilderBundle/Storage/FormInterface.php
+++ b/src/FormBuilderBundle/Storage/FormInterface.php
@@ -6,43 +6,130 @@ use Pimcore\Translation\Translator;
 
 interface FormInterface
 {
+    /**
+     * @param Translator $translator
+     *
+     * @return FormInterface|void
+     */
     public function setTranslator(Translator $translator);
 
+    /**
+     * @param string $newName
+     *
+     * @return true
+     */
     public function rename($newName);
 
+    /**
+     * @return mixed
+     */
     public function delete();
 
+    /**
+     * @return int|null
+     */
     public function getId();
 
+    /**
+     * @param string $name
+     *
+     * @return FormInterface|void
+     */
     public function setName($name);
 
+    /**
+     * @return string
+     */
     public function getName();
 
+    /**
+     * @return mixed
+     */
     public function save();
 
+    /**
+     * @param mixed $date
+     *
+     * @return FormInterface|void
+     */
     public function setDate($date);
 
+    /**
+     * @return mixed
+     */
     public function getDate();
 
-    public function setConfig($config);
+    /**
+     * @param array $config
+     *
+     * @return FormInterface|void
+     */
+    public function setConfig(array $config);
 
+    /**
+     * @return array
+     */
     public function getConfig();
 
-    public function setConditionalLogic($data);
+    /**
+     * @param array $data
+     *
+     * @return FormInterface|void
+     */
+    public function setConditionalLogic(array $data);
 
+    /**
+     * @return array
+     */
     public function getConditionalLogic();
 
+    /**
+     * @param string $name
+     * @param string $type
+     * @param array  $options
+     * @param array  $optional
+     *
+     * @return FormInterface|void
+     */
     public function addDynamicField($name, $type, $options, $optional = []);
 
+    /**
+     * @param array $fields
+     *
+     * @return FormInterface|void
+     */
     public function setFields(array $fields);
 
+    /**
+     * @return array
+     */
     public function getFields();
 
-    public function getFieldsByType($type);
+    /**
+     * @param string $type
+     *
+     * @return FormFieldInterface[]
+     */
+    public function getFieldsByType(string $type);
 
-    public function getField($name);
+    /**
+     * @param string $name
+     *
+     * @return FormFieldInterface|null
+     */
+    public function getField(string $name);
 
-    public function getFieldType($name);
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function getFieldType(string $name);
 
-    public function getFieldValue($name);
+    /**
+     * @param string $name
+     *
+     * @return string|array
+     */
+    public function getFieldValue(string $name);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #115 

Added PHPDoc to the Storage interfaces (FormBuilderBundle\Storage\*Interface) with matching return types to get IDE autocompletion.
In addition I adjustet the classes which implement the interfaces with correct typehinting & PHPDoc blocks and return values.