### PR TITLE
skip ghost attachments in copy mail

### DIFF
--- a/src/FormBuilderBundle/EventListener/MailListener.php
+++ b/src/FormBuilderBundle/EventListener/MailListener.php
@@ -162,7 +162,7 @@ class MailListener implements EventSubscriberInterface
         }
 
         $attachments = [];
-        if ($data->hasAttachments()) {
+        if ($data->hasAttachments() && $isCopy === false) {
             $attachments = $data->getAttachments();
         }
 

--- a/src/FormBuilderBundle/EventSubscriber/FormBuilderSubscriber.php
+++ b/src/FormBuilderBundle/EventSubscriber/FormBuilderSubscriber.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRegistryInterface;
+use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -174,7 +175,7 @@ class FormBuilderSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var \Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag $sessionBag */
+        /** @var NamespacedAttributeBag $sessionBag */
         $sessionBag = $this->session->getBag('form_builder_session');
 
         //handle linked assets.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | /no
| Fixed tickets | --
| Versions | `2.7`, `3.0`


Do not send empty attachment blocks in copy mail.