### PR TITLE
Fix dynamic choice type service detection

### DIFF
--- a/src/FormBuilderBundle/Form/Type/DynamicChoiceType.php
+++ b/src/FormBuilderBundle/Form/Type/DynamicChoiceType.php
@@ -56,7 +56,7 @@ class DynamicChoiceType extends AbstractType
             'choice_translation_domain' => false,
             'choice_loader'             => function (Options $options) {
                 $initialChoiceBuilder = false;
-                if (!$this->service) {
+                if (!$this->service || get_class($this->service) !== $options['service']) {
                     $serviceName = $options['service'];
                     $this->service = $this->builderRegistry->get($serviceName);
                     $initialChoiceBuilder = true;


### PR DESCRIPTION
When two different dynamic choice services were specified,
the first one was used for all dynamic choice types.

| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no, well somehow?
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | don't know any
