### PR TITLE
enable html5 as checkbox for date-fieldtype, resolves #190

### DIFF
--- a/docs/30_FormTypes.md
+++ b/docs/30_FormTypes.md
@@ -16,7 +16,7 @@ There are several form types available (updated continuously).
 | Html Tag | Other Fields | Create a label, or headline element (tags can be defined via parameter) |
 | Snippet | Other Fields | Place a custom (localized) snippet in your form. |
 | [Dynamic Multi File](80_FileUpload.md) | Other Fields | Multi-File Upload field. |
-| Date | Date and Time Fields | A field that allows the user to modify date information via a variety of different HTML elements. |
+| Date | Date and Time Fields | A field that allows the user to modify date information via a variety of different HTML elements. Now supports usage of text- or html5-datetype |
 | Date Time | Date and Time Fields | This field type allows the user to modify data that represents a specific date and time (e.g. 1984-06-05 12:15:30). |
 | Time | Date and Time Fields | This can be rendered as a text field, a series of text fields (e.g. hour, minute, second) or a series of select fields. The underlying data can be stored as a DateTime object, a string, a timestamp or an array. |
 | Birthday | Date and Time Fields | Can be rendered as a single text box, three text boxes (month, day and year), or three select boxes. |

--- a/docs/90_FrontendTips.md
+++ b/docs/90_FrontendTips.md
@@ -44,7 +44,7 @@ $('.custom-datepicker').datepicker();
 ````
 
 ### Multilanguage support
-For date-fields, there needs to be done more, since symfony expects the date to match following pattern, which only works in english:
+For date-fields, there needs to be done more, since symfony expects the date to match following pattern:
 
 ```php
     # Symfony\Component\Form\Extension\Core\Type\DateType.php:

--- a/docs/90_FrontendTips.md
+++ b/docs/90_FrontendTips.md
@@ -53,7 +53,7 @@ For date-fields, there needs to be done more, since symfony expects the date to 
 
 Here is a way to implement the use of a different language for the frontend, while sending the correct format to symfony.
 
-In this example, following packages are used: 
+In this example, following npm-packages are used: 
 - "@chenfengyuan/datepicker": "^1.0.8",
 - "moment": "^2.24.0",
         

--- a/docs/90_FrontendTips.md
+++ b/docs/90_FrontendTips.md
@@ -29,3 +29,76 @@ Just use the translation html editor to define some html label:
 
 ![labels with html](https://user-images.githubusercontent.com/700119/54492883-97453680-48ca-11e9-9abe-d43d1d89a505.png)
 
+## HTML in Checkbox / Radio Labels
+Formbuilder allows you to use HTML tags in checkbox and radio labels.
+Just use the translation html editor to define some html label:
+
+![labels with html](https://user-images.githubusercontent.com/700119/54492883-97453680-48ca-11e9-9abe-d43d1d89a505.png)
+
+## Custom datepicker in date-fields
+Add standard attribute class="custom-datepicker" to the field where you want it, untick html5-checkbox (available from tags 2.7.3 and 3.0.3 upwards)
+
+and initialize your datepicker, p.e.: 
+````javascript
+$('.custom-datepicker').datepicker();
+````
+
+### Multilanguage support
+For date-fields, there needs to be done more, since symfony expects the date to match following pattern, which only works in english:
+
+```php
+    # Symfony\Component\Form\Extension\Core\Type\DateType.php:
+    const HTML5_FORMAT = 'yyyy-MM-dd';
+```
+
+Here is a way to implement the use of a different language for the frontend, while sending the correct format to symfony.
+
+In this example, following packages are used: 
+- "@chenfengyuan/datepicker": "^1.0.8",
+- "moment": "^2.24.0",
+        
+... and only english and german is supported. (Make sure that your datepicker supports multiple languages and include them.)
+
+
+```javascript
+    var langIso = WEBSITE_CONFIG.language === 'en' ? 'en-GB' : 'de-DE',
+        displayFieldSuffix = '_display';
+
+    // datepicker formats
+    $.fn.datepicker.languages['en-GB'] = {
+        format: 'yyyy-MM-dd'
+    };
+    $.fn.datepicker.languages['de-DE'] = {
+        format: 'd.M.yyyy'
+    };
+
+    $('form.formbuilder input.custom-datepicker').each(function () {
+        // iconDiv is a wrapper element to show an icon in the input-field via css (since inputfields do not support ::after/::before);
+        // iconDiv will contain a modified clone of the original element, because we need different date-formats for frontend and form-submission
+        var iconDiv = document.createElement('div'),
+            displayInputField = $(this).clone();
+
+        $(iconDiv).addClass('date-icon');
+
+        displayInputField.attr('name', null); // !! form-elements without name are not submitted
+        displayInputField.attr('id', displayInputField.attr('id') + displayFieldSuffix);
+        $(displayInputField).addClass('datepicker-display'); // for later selector
+        
+        $(iconDiv).append(displayInputField);
+
+        this.style.display = 'none';
+        $(this).parent('.form-group').append(iconDiv);
+    });
+
+    $('form.formbuilder input.custom-datepicker.datepicker-display').removeAttr('data-template').removeData('template').each(function () {
+        var origId = this.id,
+            displayFieldId = origId.substring(0, origId.length - displayFieldSuffix.length);
+
+        $(this).datepicker({
+            language: langIso,
+            autoHide: true,
+        }).on('change', function () {
+            $('#' + displayFieldId).val(moment($('#' + origId).val(), $.fn.datepicker.languages[langIso].format.toUpperCase(), true).format('YYYY-MM-DD'));
+        });
+    });
+```

--- a/docs/90_FrontendTips.md
+++ b/docs/90_FrontendTips.md
@@ -53,12 +53,13 @@ For date-fields, there needs to be done more, since symfony expects the date to 
 
 Here is a way to implement the use of a different language for the frontend, while sending the correct format to symfony.
 
-In this example, following npm-packages are used: 
-- "@chenfengyuan/datepicker": "^1.0.8",
-- "moment": "^2.24.0",
-        
-... and only english and german is supported. (Make sure that your datepicker supports multiple languages and include them.)
-
+In following example, these npm-packages are used: 
+````json
+{
+    "@chenfengyuan/datepicker": "^1.0.8",
+    "moment": "^2.24.0"
+}
+````
 
 ```javascript
     var langIso = WEBSITE_CONFIG.language === 'en' ? 'en-GB' : 'de-DE',

--- a/src/FormBuilderBundle/Resources/config/types/field_types.yml
+++ b/src/FormBuilderBundle/Resources/config/types/field_types.yml
@@ -8,7 +8,7 @@ form_builder:
                 icon_class: 'form_builder_icon_date'
                 constraints:
                     disabled:
-                    - 'dynamic_multi_file_not_blank'
+                        - 'dynamic_multi_file_not_blank'
                 fields:
                     options.data: ~
                     options.value: ~
@@ -36,6 +36,12 @@ form_builder:
                         type: tagfield
                         label: 'form_builder_type_field.date_years'
                         config: ~
+                    options.html5:
+                        display_group_id: attributes
+                        type: checkbox
+                        label: 'use HTML5 type=date (do not use with class="custom-datepicker")'
+                        config:
+                            checked: true
         date_time:
             class: Symfony\Component\Form\Extension\Core\Type\DateTimeType
             backend:
@@ -184,6 +190,12 @@ form_builder:
                         type: tagfield
                         label: 'form_builder_type_field.date_years'
                         config: ~
+                    options.html5:
+                        display_group_id: attributes
+                        type: checkbox
+                        label: 'use HTML5 type=date (do not use with class="custom-datepicker")'
+                        config:
+                            checked: true
         text:
             class: Symfony\Component\Form\Extension\Core\Type\TextType
             backend:

--- a/src/FormBuilderBundle/Resources/config/types/field_types.yml
+++ b/src/FormBuilderBundle/Resources/config/types/field_types.yml
@@ -39,7 +39,7 @@ form_builder:
                     options.html5:
                         display_group_id: attributes
                         type: checkbox
-                        label: 'use HTML5 type=date (do not use with class="custom-datepicker")'
+                        label: 'form_builder_type_field.date_html5'
                         config:
                             checked: true
         date_time:
@@ -193,7 +193,7 @@ form_builder:
                     options.html5:
                         display_group_id: attributes
                         type: checkbox
-                        label: 'use HTML5 type=date (do not use with class="custom-datepicker")'
+                        label: 'form_builder_type_field.date_html5'
                         config:
                             checked: true
         text:

--- a/src/FormBuilderBundle/Resources/config/types/field_types.yml
+++ b/src/FormBuilderBundle/Resources/config/types/field_types.yml
@@ -110,6 +110,12 @@ form_builder:
                         display_group_id: attributes
                         type: checkbox
                         label: 'form_builder_type_field.date_with_seconds'
+                    options.html5:
+                        display_group_id: attributes
+                        type: checkbox
+                        label: 'form_builder_type_field.date_html5'
+                        config:
+                            checked: true
         time:
             class: Symfony\Component\Form\Extension\Core\Type\TimeType
             backend:

--- a/src/FormBuilderBundle/Resources/install/translations/admin.csv
+++ b/src/FormBuilderBundle/Resources/install/translations/admin.csv
@@ -111,4 +111,4 @@
 "form_builder.mail_editor.widget_provider.form_fields.show_labels","Show Labels","Labels anzeigen"
 "form_builder.mail_editor.widget_provider.date.date","Date","Datum"
 "form_builder.mail_editor.widget_provider.date.date_format","Date Format","Datum-Format"
-"form_builder_type_field.date_html5","use HTML5 type"
+"form_builder_type_field.date_html5","use HTML5 type", "HTML5-Typ benutzen"

--- a/src/FormBuilderBundle/Resources/install/translations/admin.csv
+++ b/src/FormBuilderBundle/Resources/install/translations/admin.csv
@@ -111,3 +111,4 @@
 "form_builder.mail_editor.widget_provider.form_fields.show_labels","Show Labels","Labels anzeigen"
 "form_builder.mail_editor.widget_provider.date.date","Date","Datum"
 "form_builder.mail_editor.widget_provider.date.date_format","Date Format","Datum-Format"
+"form_builder_type_field.date_html5","use HTML5 type=date (do not use with class='custom-datepicker')","HTML5 type=date benutzen (nicht verwenden mit class='custom-datepicker')"

--- a/src/FormBuilderBundle/Resources/install/translations/admin.csv
+++ b/src/FormBuilderBundle/Resources/install/translations/admin.csv
@@ -111,4 +111,4 @@
 "form_builder.mail_editor.widget_provider.form_fields.show_labels","Show Labels","Labels anzeigen"
 "form_builder.mail_editor.widget_provider.date.date","Date","Datum"
 "form_builder.mail_editor.widget_provider.date.date_format","Date Format","Datum-Format"
-"form_builder_type_field.date_html5","use HTML5 type=date (do not use with class='custom-datepicker')","HTML5 type=date benutzen (nicht verwenden mit class='custom-datepicker')"
+"form_builder_type_field.date_html5","use HTML5 type"

--- a/src/FormBuilderBundle/Resources/public/js/comp/config_fields/checkbox.js
+++ b/src/FormBuilderBundle/Resources/public/js/comp/config_fields/checkbox.js
@@ -1,11 +1,10 @@
 pimcore.registerNS('Formbuilder.comp.type.config_fields.checkbox');
 Formbuilder.comp.type.config_fields.checkbox = Class.create(Formbuilder.comp.type.config_fields.abstract, {
-    getField: function(fieldConfig, value)
-    {
+    getField: function (fieldConfig, value) {
         return new Ext.form.Checkbox({
             fieldLabel: fieldConfig.label,
             name: fieldConfig.id,
-            checked: false,
+            checked: fieldConfig.hasOwnProperty('config') && fieldConfig.config.hasOwnProperty('checked') ? fieldConfig.config.checked : false,
             uncheckedValue: false,
             inputValue: true,
             value: value


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 for bug fixes
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #190 

enable html5-config on date-fieldtypes