### PR TITLE
Make honeypot field optional (fix #167)

### DIFF
--- a/docs/100_ConfigurationFlags.md
+++ b/docs/100_ConfigurationFlags.md
@@ -3,6 +3,7 @@
 | Name | Type | Default
 |------|------|------------|
 | `use_custom_radio_checkbox` | bool | true |
+| `use_honeypot_field` | bool | true |
 
 ***
 
@@ -13,4 +14,13 @@ Change `use_custom_radio_checkbox` to false, if you don't want to use the bootst
 form_builder:
     flags:
         use_custom_radio_checkbox: false
+```
+
+## 🚩 use_honeypot_field flag
+Change `use_honeypot_field` to false, if you don't want a honeypot field added to your forms.
+
+```yaml
+form_builder:
+    flags:
+        use_honeypot_field: false
 ```

--- a/docs/90_FrontendTips.md
+++ b/docs/90_FrontendTips.md
@@ -23,6 +23,9 @@ input[name$='[inputUserName]'] {
 
 ```
 
+You can also disable the honeypot field entirely by setting the `use_honeypot_field`
+[configuration flag](100_ConfigurationFlags.md) to false.
+
 ## HTML in Checkbox / Radio Labels
 Formbuilder allows you to use HTML tags in checkbox and radio labels.
 Just use the translation html editor to define some html label:

--- a/src/FormBuilderBundle/DependencyInjection/Configuration.php
+++ b/src/FormBuilderBundle/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('use_custom_radio_checkbox')->defaultValue(true)->end()
+                        ->booleanNode('use_honeypot_field')->defaultValue(true)->end()
                     ->end()
                 ->end()
                 ->arrayNode('area')

--- a/src/FormBuilderBundle/Form/Builder.php
+++ b/src/FormBuilderBundle/Form/Builder.php
@@ -138,6 +138,7 @@ class Builder
                 'action'            => $formConfig['action'] === '/' ? $request->getUri() : $formConfig['action'],
                 'current_form_id'   => $formEntity->getId(),
                 'conditional_logic' => $formEntity->getConditionalLogic(),
+                'add_honeypot'      => $this->configuration->getConfigFlag('use_honeypot_field'),
                 'attr'              => $formAttributes,
             ]
         );

--- a/src/FormBuilderBundle/Form/Type/DynamicFormType.php
+++ b/src/FormBuilderBundle/Form/Type/DynamicFormType.php
@@ -22,8 +22,11 @@ class DynamicFormType extends AbstractType
             ])
             ->add('formCl', HiddenType::class, [
                 'data' => !empty($options['conditional_logic']) ? json_encode($options['conditional_logic']) : null,
-            ])
-            ->add('inputUserName', HoneypotType::class);
+            ]);
+
+        if ($options['add_honeypot']) {
+            $builder->add('inputUserName', HoneypotType::class);
+        }
     }
 
     /**
@@ -34,6 +37,7 @@ class DynamicFormType extends AbstractType
         $resolver->setDefaults([
             'current_form_id'    => 0,
             'conditional_logic'  => [],
+            'add_honeypot'       => true,
             'allow_extra_fields' => true,
             'csrf_protection'    => true,
             'data_class'         => Form::class


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #167 

Add a configuration flag to prevent the honeypot field from being added to the form.