### PR TITLE
feature/refactor-core-fb-js

### DIFF
--- a/docs/91_Javascript.md
+++ b/docs/91_Javascript.md
@@ -20,41 +20,50 @@ This Plugin will enable the ajax functionality and also the multi file handling:
 ```
 
 ```javascript
-$(function () {
-    $('form.formbuilder.ajax-form').formBuilderAjaxManager();
-});
+new Formbuilder(
+    $('form.formbuilder'))
+    .FormBuilderAjaxManager();
 ```
 ### Extended Usage
 ```javascript
-$('form.formbuilder.ajax-form').formBuilderConditionalLogic({
-    setupFileUpload: true, // initialize upload fields
-    resetFormMethod: null, // reset method after success
-    validationTransformer: {
-        addValidationMessage: function($fields, messages) {
-            console.log($fields, messages);
-        },
-        removeFormValidations: function($form) {
-            console.log($form);
-        }
-    }
-});
+new Formbuilder(
+    $('form.formbuilder'))
+    .FormBuilderAjaxManager(
+        {
+            checkOnChange: true, // check if invalid fields after the submit were corrected
+            setupFileUpload: true, // initialize upload fields
+            resetFormMethod: null, // reset method after success,
+            validationTransformer: {
+                addValidationMessage: function($fields, messages) {
+                    console.log($fields, messages);
+                },
+                removeFormValidations: function($form) {
+                    console.log($form);
+                }
+            }
+        });
 ```
 
 ### Events
 
 ```javascript
-$('form.ajax-form')
-   .on('formbuilder.success', function(ev, message, redirect, $form) {
-         console.log(message, redirect);
- }).on('formbuilder.error', function(ev, messages, $form) {
-         console.log(messages);
- }).on('formbuilder.error-form', function (ev, messages, $form) {
+$(form)
+    .on('formbuilder.success', function (ev, message, redirect, $form) {
+        console.log(message, redirect);
+    })
+    .on('formbuilder.error', function (ev, messages, $form) {
+        console.log(messages);
+    })
+    .on('formbuilder.error-form', function (ev, messages, $form) {
         console.error('error-form', messages);
- }).on('formbuilder.error-field', function(ev, data, $form) {
-         console.log(data.field, data.messages);
- }).on('formbuilder.fatal', function (ev, response, $form) {
+    })
+    .on('formbuilder.error-field', function (ev, data, $form) {
+        console.log(data.field, data.messages);
+    })
+    .on('formbuilder.fatal', function (ev, response, $form) {
         console.error('fatal', response.error, response.trace);
 });
+
 ```
 
 ## Conditional Logic Extension

--- a/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.core.form-builder.js
+++ b/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.core.form-builder.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*
  *  Project: PIMCORE FormBuilder
  *  Extension: Core
@@ -15,24 +17,35 @@
  *     console.log(data.field, data.messages);
  * });
 */
-;(function ($, window, document) {
-    'use strict';
-    var clName = 'FormBuilderAjaxManager';
 
-    function ValidationTransformer(options, formTemplate) {
-        this.formTemplate = formTemplate;
+export class Formbuilder {
+    constructor(el) {
+        this.$form = el;
+        this.window = window;
+        this.document = document;
+        this.defaults = {
+            setupFileUpload: false,
+            validationTransformer: {},
+            resetFormMethod: null
+        };
+        this.formMethod = 'post';
+        this.validationTransformer = null;
+    }
+
+    ValidationTransformer(options, formTemplate) {
         this.userMethods = options;
+        this.formTemplate = formTemplate;
         this.themeTransform = {
             'bootstrap3': {
                 addValidationMessage: function ($fields, messages) {
-                    var $field = $fields.first(),
+                    let $field = $fields.first(),
                         $formGroup = $field.closest('.form-group');
 
                     $formGroup.addClass('has-error');
                     $formGroup.find('span.help-block.validation').remove();
 
                     $.each(messages, function (validationType, message) {
-                        var $spanEl = $('<span/>', {'class': 'help-block validation', 'text': message});
+                        let $spanEl = $('<span/>', {'class': 'help-block validation', 'text': message});
                         if ($fields.length > 1) {
                             $field.closest('label').before($spanEl);
                         } else {
@@ -47,7 +60,7 @@
             },
             'bootstrap4': {
                 addValidationMessage: function ($fields, messages) {
-                    var $field = $fields.first(),
+                    let $field = $fields.first(),
                         $formGroup = $field.closest('.form-group'),
                         isDiv = $field.prop('nodeName') === 'DIV',
                         isMultipleInputElement = false;
@@ -69,7 +82,7 @@
                     $field.closest('form').addClass('was-validated');
 
                     $.each(messages, function (validationType, message) {
-                        var $spanEl = $('<span/>', {'class': 'invalid-feedback validation', 'text': message});
+                        let $spanEl = $('<span/>', {'class': 'invalid-feedback validation', 'text': message});
 
                         // multiple radio / checkbox:
                         // at least one checked strategy: add feedback message out of a single element
@@ -82,7 +95,7 @@
                     });
                 },
                 removeFormValidations: function ($form) {
-                    var $multipleValidatedInputElements;
+                    let $multipleValidatedInputElements;
 
                     $form.removeClass('was-validated');
                     $form.find('.is-invalid').removeClass('is-invalid');
@@ -96,12 +109,55 @@
                         $multipleValidatedInputElements.find('input:checkbox,input:radio').removeAttr('required');
                     }
                 }
+            },
+            'divLayout': {
+                addValidationMessage: function ($fields, messages) {
+                    let $field = $fields.first(),
+                        $formGroup = $field.closest('.form__item'),
+                        isDiv = $field.prop('nodeName') === 'DIV',
+                        isMultipleInputElement = false;
+
+                    $fields.addClass('is-invalid');
+
+                    $formGroup.each(function () {
+                        $(this).addClass('has-error');
+                        $(this).find('span.invalid-feedback.validation').remove();
+                    });
+
+                    if (isDiv === true) {
+                        isMultipleInputElement = $field.find('input:checkbox,input:radio').length > 0;
+                    }
+
+                    if (isMultipleInputElement) {
+                        $field.find('input:checkbox,input:radio').attr('required', 'required');
+                    }
+
+                    $field.closest('form').addClass('was-validated');
+
+                    $.each(messages, function (validationType, message) {
+                        let $spanEl = $('<span/>', {'class': 'invalid-feedback validation', 'text': message});
+
+                        // multiple radio / checkbox:
+                        // at least one checked strategy: add feedback message out of a single element
+                        if (isMultipleInputElement) {
+                            $field.addClass('fb-multiple-input-validated');
+                            $field.append($spanEl.addClass('d-block'));
+                        } else {
+                            $formGroup.after($spanEl);
+                        }
+                    });
+                },
+                removeFormValidations: function ($form) {
+                    $form.removeClass('was-validated');
+                    $form.find('.is-invalid').removeClass('is-invalid');
+                    $form.find('.has-error').removeClass('has-error');
+                    $form.find('span.invalid-feedback.validation').remove();
+                }
             }
         };
 
         this.transform = function () {
-
-            var args = Array.prototype.slice.call(arguments),
+            let args = Array.prototype.slice.call(arguments),
                 action = args.shift();
 
             if (typeof this.userMethods[action] === 'function') {
@@ -115,273 +171,270 @@
                 case 'bootstrap_4_layout':
                 case 'bootstrap_4_horizontal_layout':
                     return this.themeTransform.bootstrap4[action].apply(null, args);
+                case 'form_div_layout':
+                    return this.themeTransform.divLayout[action].apply(null, args);
                 default:
                     console.warn('unknown validation transformer action.', action);
                     break;
             }
-        }
+        };
     }
 
-    function FormBuilderAjaxManager(form, options) {
-        this.$form = $(form);
+    FormBuilderAjaxManager(options) {
         this.formTemplate = this.$form.data('template');
-        this.options = $.extend({}, $.fn.formBuilderAjaxManager.defaults, options);
+        this.options = $.extend({}, this.defaults, options);
         this.ajaxUrls = {};
-        this.validationTransformer = new ValidationTransformer(this.options.validationTransformer, this.formTemplate);
+        this.validationTransformer = new this.ValidationTransformer(this.options.validationTransformer, this.formTemplate);
 
         window.formBuilderGlobalContext = {};
 
         this.init();
-
     }
 
-    $.extend(FormBuilderAjaxManager.prototype, {
+    init() {
+        this.setAjaxFileStructureUrls();
+        this.formMethod = this.$form.attr('method');
+        this.submitForms();
+        if (this.options.checkOnChange) {
+            this.changeForms();
+        }
+    }
 
-        init: function () {
-            this.setAjaxFileStructureUrls();
-            this.loadForms();
-        },
+    removeValidations() {
+        this.validationTransformer.transform('removeFormValidations', this.$form);
+    }
 
-        loadForms: function () {
+    submitForms() {
+        this.loadForms('submit', this.$form);
+    }
 
-            var _ = this;
+    changeForms() {
+        this.loadForms('change', 'input.is-invalid');
+    }
 
-            this.$form.on('submit', function (ev) {
+    loadForms(action, el) {
+        let _ = this;
+        let $form = this.$form;
 
-                if (_.ajaxUrls.length === 0) {
-                    alert('formbuilder ajax url structure missing.');
-                }
-
-                var $form = $(this),
-                    $btns = $form.find('.btn'),
-                    $fbHtmlFile = $form.find('.dynamic-multi-file');
-
-                ev.preventDefault();
-
-                $btns.attr('disabled', 'disabled');
-
-                if ($fbHtmlFile.length > 0) {
-                    $form.find('.qq-upload-delete').hide();
-                }
-
-                $.ajax({
-                    type: $form.attr('method'),
-                    url: _.getAjaxFileUrl('form_parser'),
-                    data: ($form.attr('method') === 'get') ? $form.serialize() : new FormData($form[0]),
-                    processData: ($form.attr('method') === 'get'),
-                    contentType: ($form.attr('method') === 'get') ? $form.attr('enctype') : false,
-                    success: function (response) {
-
-                        var generalFormErrors = [];
-
-                        $btns.attr('disabled', false);
-
-                        _.validationTransformer.transform('removeFormValidations', $form);
-
-                        if ($fbHtmlFile.length > 0) {
-                            $form.find('.qq-upload-delete').show();
-                        }
-
-                        if (response.success === false) {
-                            if (typeof response.validation_errors === 'object' && Object.keys(response.validation_errors).length > 0) {
-                                $.each(response.validation_errors, function (fieldId, messages) {
-                                    if (fieldId === 'general') {
-                                        generalFormErrors = messages;
-                                    } else {
-                                        var $fields = $form.find('[id="' + fieldId + '"]');
-
-                                        //fallback for radio / checkbox
-                                        if ($fields.length === 0) {
-                                            $fields = $form.find('[id^="' + fieldId + '"]');
-                                        }
-
-                                        //fallback for custom fields (like ajax file, headline or snippet type)
-                                        if ($fields.length === 0) {
-                                            $fields = $form.find('[data-field-name*="' + fieldId + '"]');
-                                        }
-
-                                        if ($fields.length > 0) {
-                                            _.validationTransformer.transform('addValidationMessage', $fields, messages);
-                                            $form.trigger('formbuilder.error-field', [{
-                                                'field': $fields.first(),
-                                                'messages': messages
-                                            }, $form]);
-                                        }
-                                    }
-                                });
-
-                                if (generalFormErrors.length > 0) {
-                                    $form.trigger('formbuilder.error-form', [generalFormErrors, $form]);
-                                }
-
-                            } else {
-                                if (response.error) {
-                                    $form.trigger('formbuilder.fatal', [response, $form]);
-                                } else {
-                                    $form.trigger('formbuilder.error', [response.messages, $form]);
-                                }
-                            }
-
-                        } else {
-
-                            $form.trigger('formbuilder.success', [response.messages, response.redirect, $form]);
-
-                            if (typeof _.options.resetFormMethod === 'function') {
-                                _.options.resetFormMethod.apply(null, $form);
-                            } else {
-                                $form.trigger('reset');
-                                // in case conditional logic is active.
-                                $form.find('input, textarea').trigger('change');
-                            }
-
-                            if ($fbHtmlFile.length > 0) {
-                                $fbHtmlFile.fineUploader('reset');
-                                $fbHtmlFile.find('input[type="hidden"]').val('');
-                            }
-
-                            //@todo: recaptcha is currently not implemented
-                            //if (typeof grecaptcha === 'object' && $form.find('.g-recaptcha:first').length > 0) {
-                            //    grecaptcha.reset();
-                            //}
-                        }
-                    }
-                });
-            });
-        },
-
-        /**
-         * Setup File Upload Field (fineUploader is required!)
-         */
-        setupDynamicMultiFile: function () {
-
-            var _ = this;
-
-            if (!this.options.setupFileUpload) {
-                return;
+        $form.on(action, el, function (ev) {
+            ev.preventDefault();
+            if (_.ajaxUrls.length === 0) {
+                console.warn('formbuilder ajax url structure missing.');
             }
 
-            if (jQuery().fineUploader === undefined) {
-                console.warn('fine uploader not found. please include the js library!');
-            }
-
-            this.$form.find('.dynamic-multi-file').each(function () {
-
-                var $el = $(this),
-                    $form = $el.closest('form'),
-                    $submitButton = $form.find('*[type="submit"]'),
-                    $template = $el.find('.qq-uploader-wrapper:first'),
-                    $element = $el.find('.qq-upload-container'),
-                    fieldName = $el.data('field-name'),
-                    $storeField = $el.find('input[type="hidden"]'),
-                    formId = parseInt($form.find('input[name*="formId"]').val()),
-                    config = window[fieldName + '_dmf_config'];
+            let $btns = $form.find('.button'),
+                $fbHtmlFile = $form.find('.dynamic-multi-file');
 
 
-                $el.fineUploader({
-                    debug: false,
-                    template: $template,
-                    element: $element,
-                    messages: config.messages.core,
-                    text: {
-                        formatProgress: config.messages.text.formatProgress,
-                        failUpload: config.messages.text.failUpload,
-                        waitingForResponse: config.messages.text.waitingForResponse,
-                        paused: config.messages.text.paused
-                    },
-                    chunking: {
-                        enabled: true,
-                        concurrent: {
-                            enabled: true
-                        },
-                        success: {
-                            endpoint: _.getAjaxFileUrl('file_chunk_done'),
-                        }
-                    },
-                    request: {
-                        endpoint: _.getAjaxFileUrl('file_add'),
-                        params: {
-                            formId: formId,
-                            fieldName: fieldName
-                        }
-                    },
-                    deleteFile: {
-                        confirmMessage: config.messages.delete.confirmMessage,
-                        deletingStatusText: config.messages.delete.deletingStatusText,
-                        deletingFailedText: config.messages.delete.deletingFailedText,
+            $btns.attr('disabled', 'disabled');
 
-                        enabled: true,
-                        endpoint: _.getAjaxFileUrl('file_delete'),
-                        params: {
-                            formId: formId,
-                            fieldName: fieldName
-                        }
-                    },
-                    validation: {
-                        sizeLimit: config.max_file_size,
-                        allowedExtensions: config.allowed_extensions,
-                        itemLimit: config.item_limit
-                    },
-                    callbacks: {
-                        onUpload: function () {
-                            $submitButton.attr('disabled', 'disabled');
-                        },
-                        onComplete: function (id, name, data) {
-                            $storeField.val($storeField.val() + ',' + data.uuid);
-                            $submitButton.attr('disabled', false);
-                        },
-                        onDeleteComplete: function (id, xhr, isError) {
-                            var data = jQuery.parseJSON(xhr.responseText);
-                            if (data.success === true) {
-                                $storeField.val($storeField.val().replace(',' + data.uuid, ''));
-                            } else {
-                                $storeField.val($storeField.val().replace(',' + data.path, ''));
-
-                            }
-                        }
-                    }
-                });
-
-                $template.remove();
-
-            });
-        },
-
-        setAjaxFileStructureUrls: function () {
-
-            if (window.formBuilderGlobalContext.length > 0) {
-                this.ajaxUrls = window.formBuilderGlobalContext;
-                return;
+            if ($fbHtmlFile.length > 0) {
+                $form.find('.qq-upload-delete').hide();
             }
 
             $.ajax({
-                type: 'post',
-                url: this.$form.data('ajax-structure-url'),
+                type: _.formMethod,
+                url: _.getAjaxFileUrl('form_parser'),
+                data: (this.formMethod === 'get') ? new FormData($form.serialize()) : new FormData($form[0]),
+                processData: ($form.attr('method') === 'get'),
+                contentType: ($form.attr('method') === 'get') ? $form.attr('enctype') : false,
                 success: function (response) {
-                    this.ajaxUrls = response;
-                    window.formBuilderGlobalContext = this.ajaxUrls;
-                    this.setupDynamicMultiFile();
-                }.bind(this)
+                    let generalFormErrors = [];
+
+                    $btns.attr('disabled', false);
+                    _.removeValidations();
+
+                    if ($fbHtmlFile.length > 0) {
+                        $form.find('.qq-upload-delete').show();
+                    }
+
+                    if (response.success === false) {
+                        if (typeof response.validation_errors === 'object' && Object.keys(response.validation_errors).length > 0) {
+                            $.each(response.validation_errors, function (fieldId, messages) {
+                                if (fieldId === 'general') {
+                                    generalFormErrors = messages;
+                                } else {
+                                    let $fields = $form.find('[id="' + fieldId + '"]');
+
+                                    //fallback for radio / checkbox
+                                    if ($fields.length === 0) {
+                                        $fields = $form.find('[id^="' + fieldId + '"]');
+                                    }
+
+                                    //fallback for custom fields (like ajax file, headline or snippet type)
+                                    if ($fields.length === 0) {
+                                        $fields = $form.find('[data-field-name*="' + fieldId + '"]');
+                                    }
+
+                                    if ($fields.length > 0) {
+                                        _.validationTransformer.transform('addValidationMessage', $fields, messages);
+                                        $form.trigger('formbuilder.error-field', [{
+                                            'field': $fields.first(),
+                                            'messages': messages
+                                        },]);
+                                    }
+                                }
+                            });
+
+                            if (generalFormErrors.length > 0) {
+                                $form.trigger('formbuilder.error-form', [generalFormErrors, $form]);
+                            }
+
+                        } else {
+                            if (response.error) {
+                                $form.trigger('formbuilder.fatal', [response, $form]);
+                            } else {
+                                $form.trigger('formbuilder.error', [response.messages, $form]);
+                            }
+                        }
+
+                    } else {
+
+                        $form.trigger('formbuilder.success', [response.messages, response.redirect, $form]);
+
+                        if (typeof _.options.resetFormMethod === 'function') {
+                            _.options.resetFormMethod.apply(null, $form);
+                        } else {
+                            $form.trigger('reset');
+                            // in case conditional logic is active.
+                            $form.find('input, textarea').trigger('change');
+                        }
+
+                        if ($fbHtmlFile.length > 0) {
+                            $fbHtmlFile.fineUploader('reset');
+                            $fbHtmlFile.find('input[type="hidden"]').val('');
+                        }
+
+                        // @TODO: recaptcha is currently not implemented
+                        // if (typeof grecaptcha === 'object' && $form.find('.g-recaptcha:first').length > 0) {
+                        //     grecaptcha.reset();
+                        // }
+                    }
+                },
+                error: function (response) {
+                    console.error('Oh no! Something went wrong!', response);
+                }
             });
-        },
-
-        getAjaxFileUrl: function (section) {
-            return this.ajaxUrls[section];
-        }
-    });
-
-    $.fn.formBuilderAjaxManager = function (options) {
-        this.each(function () {
-            if (!$.data(this, 'fbam-' + clName)) {
-                $.data(this, 'fbam-' + clName, new FormBuilderAjaxManager(this, options));
-            }
         });
-        return this;
-    };
+    }
 
-    $.fn.formBuilderAjaxManager.defaults = {
-        setupFileUpload: true,
-        validationTransformer: {},
-        resetFormMethod: null
-    };
 
-})(jQuery, window, document);
+    /**
+     * Setup File Upload Field (fineUploader is required!)
+     */
+    setupDynamicMultiFile() {
+        let _ = this;
+
+        if (!this.options.setupFileUpload) {
+            return;
+        }
+
+        if (jQuery().fineUploader === undefined) {
+            console.warn('fine uploader not found. please include the js library!');
+        }
+
+        this.$form.find('.dynamic-multi-file').each(function () {
+
+            let $el = $(this),
+                $form = $el.closest('form'),
+                $submitButton = $form.find('*[type="submit"]'),
+                $template = $el.find('.qq-uploader-wrapper:first'),
+                $element = $el.find('.qq-upload-container'),
+                fieldName = $el.data('field-name'),
+                $storeField = $el.find('input[type="hidden"]'),
+                formId = parseInt($form.find('input[name*="formId"]').val()),
+                config = window[fieldName + '_dmf_config'];
+
+
+            $el.fineUploader({
+                debug: false,
+                template: $template,
+                element: $element,
+                messages: config.messages.core,
+                text: {
+                    formatProgress: config.messages.text.formatProgress,
+                    failUpload: config.messages.text.failUpload,
+                    waitingForResponse: config.messages.text.waitingForResponse,
+                    paused: config.messages.text.paused
+                },
+                chunking: {
+                    enabled: true,
+                    concurrent: {
+                        enabled: true
+                    },
+                    success: {
+                        endpoint: _.getAjaxFileUrl('file_chunk_done'),
+                    }
+                },
+                request: {
+                    endpoint: _.getAjaxFileUrl('file_add'),
+                    params: {
+                        formId: formId,
+                        fieldName: fieldName
+                    }
+                },
+                deleteFile: {
+                    confirmMessage: config.messages.delete.confirmMessage,
+                    deletingStatusText: config.messages.delete.deletingStatusText,
+                    deletingFailedText: config.messages.delete.deletingFailedText,
+
+                    enabled: true,
+                    endpoint: _.getAjaxFileUrl('file_delete'),
+                    params: {
+                        formId: formId,
+                        fieldName: fieldName
+                    }
+                },
+                validation: {
+                    sizeLimit: config.max_file_size,
+                    allowedExtensions: config.allowed_extensions,
+                    itemLimit: config.item_limit
+                },
+                callbacks: {
+                    onUpload: function () {
+                        $submitButton.attr('disabled', 'disabled');
+                    },
+                    onComplete: function (id, name, data) {
+                        $storeField.val($storeField.val() + ',' + data.uuid);
+                        $submitButton.attr('disabled', false);
+                    },
+                    onDeleteComplete: function (id, xhr) {
+                        let data = jQuery.parseJSON(xhr.responseText);
+                        if (data.success === true) {
+                            $storeField.val($storeField.val().replace(',' + data.uuid, ''));
+                        } else {
+                            $storeField.val($storeField.val().replace(',' + data.path, ''));
+
+                        }
+                    }
+                }
+            });
+
+            $template.remove();
+
+        });
+    }
+
+    setAjaxFileStructureUrls() {
+        const _ = this;
+        if (window.formBuilderGlobalContext.length > 0) {
+            this.ajaxUrls = window.formBuilderGlobalContext;
+            return;
+        }
+
+        $.ajax({
+            type: 'post',
+            url: this.$form.data('ajax-structure-url'),
+            success: function (response) {
+                this.ajaxUrls = response;
+                window.formBuilderGlobalContext = this.ajaxUrls;
+                _.setupDynamicMultiFile();
+            }.bind(this)
+        });
+    }
+
+    getAjaxFileUrl(section) {
+        return this.ajaxUrls[section];
+    }
+
+}


### PR DESCRIPTION
REFACTOR `form-builder.js` to use ES6 Class and be more modular.

- Previous setup with IIFE could not be easily expanded.
- Structure of the file used a lot of jQuery `$.extend`.
- Layout for `form_div` was missing (only Bootstrap v3 and v4).

In my current client/project we needed to use the "form_div_layout"
since we are using Foundation for our frontend. The case was missing in
the plugin and had to be extended.

I used the opportunity to refactor the code and be easier to debug. With
this change the whole core plugin should be more modular and readable.

If further changes are necessary please feel free to address them. 
We would like to have these changes as part of the core and believe 
they would be beneficial to the community as a whole. 

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | none
