### PR TITLE
Use correct function name

### DIFF
--- a/docs/91_Javascript.md
+++ b/docs/91_Javascript.md
@@ -27,7 +27,7 @@ $(function () {
 ```
 ### Extended Usage
 ```javascript
-$('form.formbuilder.ajax-form').formBuilderConditionalLogic({
+$('form.formbuilder.ajax-form').formBuilderAjaxManager({
     setupFileUpload: true, // initialize upload fields
     resetFormMethod: null, // reset method after success
     validationTransformer: {


### PR DESCRIPTION
in the extended usage example of formBuilderAjaxManager is the wrong function name

| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
