### PR TITLE
Update jquery.fb.ext.recaptcha-v3.js

### DIFF
--- a/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.ext.recaptcha-v3.js
+++ b/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.ext.recaptcha-v3.js
@@ -43,7 +43,12 @@
             this.siteKey = this.$reCaptchaField.data('site-key');
             this.action = this.$reCaptchaField.data('action-name');
 
+            // reset captcha on all events
             this.$form.on('formbuilder.success', this.onReset.bind(this));
+            this.$form.on('formbuilder.error', this.onReset.bind(this));
+            this.$form.on('formbuilder.error-field', this.onReset.bind(this));
+            this.$form.on('formbuilder.error-form', this.onReset.bind(this));
+            this.$form.on('formbuilder.fatal', this.onReset.bind(this));
 
             this.bindDependency();
 


### PR DESCRIPTION
Submitting a form with V3 using AJAX works if all fields are filled in. If any field fails validation and then the form resubmitted - the V3 captcha will fail. Logging the response from reCaptcha it says the failure reason is 'duplicate'. I believe this means the token sent has already been validated or attempted validation.

I propose resetting the token on any of the available events. This ensures a valid token is being sent for validation.

| Q             | A
| ------------- | ---
| Branch?       | dev-master for features / 2.7 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #240    <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
