### PR TITLE
adjust rename unique constraint

### DIFF
--- a/src/FormBuilderBundle/Migrations/Version20200304172137.php
+++ b/src/FormBuilderBundle/Migrations/Version20200304172137.php
@@ -26,7 +26,8 @@ class Version20200304172137 extends AbstractPimcoreMigration implements Containe
         $this->addSql('ALTER TABLE formbuilder_output_workflow_channel ADD CONSTRAINT FK_CEC462362C75DDDC FOREIGN KEY (output_workflow) REFERENCES formbuilder_output_workflow (id);');
         $this->addSql('ALTER TABLE formbuilder_output_workflow ADD CONSTRAINT FK_BCB7909761F7634C FOREIGN KEY (form_definition) REFERENCES formbuilder_forms (id);');
         $this->addSql('ALTER TABLE formbuilder_forms CHANGE mailLayout mailLayout LONGTEXT DEFAULT NULL COMMENT "(DC2Type:object)";');
-        $this->addSql('ALTER TABLE formbuilder_forms RENAME INDEX name TO UNIQ_29DA5346999517A;');
+        $this->addSql('ALTER TABLE formbuilder_forms DROP INDEX `name`;');
+        $this->addSql('ALTER TABLE formbuilder_forms ADD CONSTRAINT UNIQ_29DA5346999517A UNIQUE (`name`);');
 
         $installer = $this->container->get(Install::class);
         $installer->updateTranslations();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #243 

Rename does not exist in all supported mysql versions, therefore we have to drop the constraint index and create a new one with the doctrine name.

