### PR TITLE
Fix Bootstrap 4 overflow for dynamicmultifile_widget

### DIFF
--- a/src/FormBuilderBundle/Resources/views/Form/Theme/bootstrap_4_layout.html.twig
+++ b/src/FormBuilderBundle/Resources/views/Form/Theme/bootstrap_4_layout.html.twig
@@ -6,7 +6,7 @@
 {% use '@FormBuilder/Form/Theme/Type/container.html.twig' %}
 
 {%- block form_builder_dynamicmultifile_widget -%}
-    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
+    {%- set attr = attr|merge({class: (attr.class|default(''))|trim}) -%}
     {{ parent() }}
 {%- endblock form_builder_dynamicmultifile_widget -%}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master? And backport? 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

We noticed that the dynamicmultifile_widget would overflow its container:

<img width="459" alt="Screenshot 2020-11-24 at 18 34 19" src="https://user-images.githubusercontent.com/434495/100132622-f754f400-2e85-11eb-803c-9e5c04ca0ac4.png">

The reason seems to be that the `form-control` class has a fixed height:

<img width="284" alt="Screenshot 2020-11-24 at 18 38 30" src="https://user-images.githubusercontent.com/434495/100132651-03d94c80-2e86-11eb-9034-6d052e349084.png">

After removing it, it no longer overflows:

<img width="496" alt="Screenshot 2020-11-24 at 18 52 59" src="https://user-images.githubusercontent.com/434495/100132857-4d299c00-2e86-11eb-8b6a-4d85396c6b11.png">

It also removes the `form-control` border of course, but since the component comes with its own border, I think that it looks ok and perhaps even better that way, even though it doesn't match the theme perfectly. If it's desirable to keep the extra border from `form-control`, I'm not quite sure how to solve that easily.