### PR TITLE
Fix: Create data objects from Symfony container

### DIFF
--- a/src/FormBuilderBundle/Factory/ObjectResolverFactory.php
+++ b/src/FormBuilderBundle/Factory/ObjectResolverFactory.php
@@ -2,6 +2,7 @@
 
 namespace FormBuilderBundle\Factory;
 
+use Pimcore\Model\FactoryInterface;
 use FormBuilderBundle\Form\FormValuesOutputApplierInterface;
 use FormBuilderBundle\OutputWorkflow\Channel\Object\ExistingObjectResolver;
 use FormBuilderBundle\OutputWorkflow\Channel\Object\NewObjectResolver;
@@ -26,18 +27,26 @@ class ObjectResolverFactory implements ObjectResolverFactoryInterface
     protected $eventDispatcher;
 
     /**
+     * @var FactoryInterface
+     */
+    protected $modelFactory;
+
+    /**
      * @param DynamicObjectResolverRegistry    $dynamicObjectResolverRegistry
      * @param FormValuesOutputApplierInterface $formValuesOutputApplier
      * @param EventDispatcherInterface         $eventDispatcher
+     * @param FactoryInterface                 $modelFactory
      */
     public function __construct(
         DynamicObjectResolverRegistry $dynamicObjectResolverRegistry,
         FormValuesOutputApplierInterface $formValuesOutputApplier,
-        EventDispatcherInterface $eventDispatcher
+        EventDispatcherInterface $eventDispatcher,
+        FactoryInterface $modelFactory
     ) {
         $this->dynamicObjectResolverRegistry = $dynamicObjectResolverRegistry;
         $this->formValuesOutputApplier = $formValuesOutputApplier;
         $this->eventDispatcher = $eventDispatcher;
+        $this->modelFactory = $modelFactory;
     }
 
     /**
@@ -45,7 +54,7 @@ class ObjectResolverFactory implements ObjectResolverFactoryInterface
      */
     public function createForNewObject(array $objectMappingData)
     {
-        return new NewObjectResolver($this->formValuesOutputApplier, $this->eventDispatcher, $objectMappingData);
+        return new NewObjectResolver($this->formValuesOutputApplier, $this->eventDispatcher, $this->modelFactory, $objectMappingData);
     }
 
     /**
@@ -53,7 +62,7 @@ class ObjectResolverFactory implements ObjectResolverFactoryInterface
      */
     public function createForExistingObject(array $objectMappingData)
     {
-        $object = new ExistingObjectResolver($this->formValuesOutputApplier, $this->eventDispatcher, $objectMappingData);
+        $object = new ExistingObjectResolver($this->formValuesOutputApplier, $this->eventDispatcher, $this->modelFactory, $objectMappingData);
         $object->setDynamicObjectResolverRegistry($this->dynamicObjectResolverRegistry);
 
         return $object;

--- a/src/FormBuilderBundle/OutputWorkflow/Channel/Object/AbstractObjectResolver.php
+++ b/src/FormBuilderBundle/OutputWorkflow/Channel/Object/AbstractObjectResolver.php
@@ -3,6 +3,7 @@
 namespace FormBuilderBundle\OutputWorkflow\Channel\Object;
 
 use Pimcore\Model\DataObject;
+use Pimcore\Model\FactoryInterface;
 use FormBuilderBundle\FormBuilderEvents;
 use FormBuilderBundle\Form\FormValuesOutputApplierInterface;
 use FormBuilderBundle\Exception\OutputWorkflow\GuardException;
@@ -52,17 +53,25 @@ abstract class AbstractObjectResolver
     protected $workflowName;
 
     /**
+     * @var FactoryInterface
+     */
+    protected $modelFactory;
+
+    /**
      * @param FormValuesOutputApplierInterface $formValuesOutputApplier
      * @param EventDispatcherInterface         $eventDispatcher
+     * @param FactoryInterface                 $modelFactory
      * @param array                            $objectMappingData
      */
     public function __construct(
         FormValuesOutputApplierInterface $formValuesOutputApplier,
         EventDispatcherInterface $eventDispatcher,
+        FactoryInterface $modelFactory,
         array $objectMappingData
     ) {
         $this->formValuesOutputApplier = $formValuesOutputApplier;
         $this->eventDispatcher = $eventDispatcher;
+        $this->modelFactory = $modelFactory;
         $this->objectMappingData = $objectMappingData;
     }
 

--- a/src/FormBuilderBundle/OutputWorkflow/Channel/Object/NewObjectResolver.php
+++ b/src/FormBuilderBundle/OutputWorkflow/Channel/Object/NewObjectResolver.php
@@ -61,7 +61,7 @@ class NewObjectResolver extends AbstractObjectResolver
         $pathName = sprintf('\Pimcore\Model\DataObject\%s', ucfirst($this->getResolvingObjectClass()));
 
         /** @var DataObject\Concrete $object */
-        $object = new $pathName();
+        $object = $this->modelFactory->build($pathName);
 
         $object->setParent($storageFolder);
         $object->setKey(uniqid(sprintf('form-%d-', $formData->getFormDefinition()->getId())));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master?
| Bug fix?      | sort of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Since Pimcore support [overriding models](https://pimcore.com/docs/pimcore/current/Development_Documentation/Extending_Pimcore/Overriding_Models.html), data objects should always be created from the Symfony container, so that the override is returned if a class has been overriden.

The gist of this PR is the replacement of

    $object = new $pathName();

with

    $object = $this->modelFactory->build($pathName);

The rest is just the necessary glue to get the [model factory](https://github.com/pimcore/pimcore/blob/master/lib/Model/Factory.php) into where we need it.

I'm not familiar with Pimcore 5.x, but let me know if you want me to rebase this onto 2.7 instead of master.