### PR TITLE
Tagline Field Error: If selectOnFocus is enabled the combo must be editable: true

### DIFF
--- a/src/FormBuilderBundle/Resources/public/js/extjs/_form/config-fields/tagfield.js
+++ b/src/FormBuilderBundle/Resources/public/js/extjs/_form/config-fields/tagfield.js
@@ -22,6 +22,7 @@ Formbuilder.extjs.form.fields.tagfield = Class.create(Formbuilder.extjs.form.fie
             valueField: 'index',
             hideTrigger: true,
             editable: !hasStore,
+            selectOnFocus: !hasStore,
             anchor: '100%'
         });
     }


### PR DESCRIPTION
Fix for this error message when using the tagline field:
[E] Ext.form.field.ComboBox.initComponent(): If selectOnFocus is enabled the combo must be editable: true -- please change one of those settings.