### PR TITLE
Don't rely on numerically keyed array

### DIFF
--- a/src/FormBuilderBundle/OutputWorkflow/Channel/Email/Parser/MailParser.php
+++ b/src/FormBuilderBundle/OutputWorkflow/Channel/Email/Parser/MailParser.php
@@ -284,9 +284,11 @@ class MailParser
     {
         $data = '';
         if (is_array($field)) {
+            $i = 0;
             foreach ($field as $k => $f) {
+                $i++;
                 $data .= $this->parseStringForOutput($f);
-                if ($k + 1 !== count($field)) {
+                if ($i !== count($field)) {
                     $data .= $separator;
                 }
             }


### PR DESCRIPTION
If a custom field type returns an associative array this will unnecessarily trip up.