### PR TITLE
Output Workflow: Submit Object Mapping form params via POST

### DIFF
--- a/src/FormBuilderBundle/Resources/config/pimcore/routing.yml
+++ b/src/FormBuilderBundle/Resources/config/pimcore/routing.yml
@@ -126,7 +126,7 @@ form_builder.controller.admin.output_workflow.object.get_field_collection_types:
 form_builder.controller.admin.output_workflow.object.get_form_data:
     path: /admin/formbuilder/output-workflow/object/get-form-data
     defaults: { _controller: FormBuilderBundle\Controller\Admin\OutputWorkflowObjectController::getFormDataAction }
-    methods: [GET]
+    methods: [POST]
 
 form_builder.controller.admin.output_workflow.object.get_dynamic_object_resolver:
     path: /admin/formbuilder/output-workflow/object/get-dynamic-object-resolver

--- a/src/FormBuilderBundle/Resources/public/js/extjs/extensions/formObjectMappingEditor.js
+++ b/src/FormBuilderBundle/Resources/public/js/extjs/extensions/formObjectMappingEditor.js
@@ -134,6 +134,7 @@ Formbuilder.extjs.extensions.formObjectMappingEditor = Class.create({
 
         Ext.Ajax.request({
             url: '/admin/formbuilder/output-workflow/object/get-form-data',
+            method: 'POST',
             params: {
                 id: this.formId,
                 baseConfiguration: Ext.encode(this.baseConfiguration),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Since the `baseConfiguration` in the `GET` parameter can become very long, the request may fail in some environments because the maximum length or size has been exceeded. To prevent this from becoming a problem at all, the parameters can be sent via `POST`.
