### PR TITLE
Adds fatal error event for captcha

### DIFF
--- a/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.ext.recaptcha-v3.js
+++ b/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.ext.recaptcha-v3.js
@@ -64,7 +64,9 @@
 
         injectTokenToForm: function () {
             try {
-                grecaptcha.execute(this.siteKey, { action: this.action }).then(this.onTokenGenerated.bind(this));
+                grecaptcha.execute(this.siteKey, { action: this.action }).then(this.onTokenGenerated.bind(this), function() => {
+                    this.$form.trigger('formbuilder.fatal-captcha', [null, this.$form]);
+                });
             } catch (error) {
                 this.$form.trigger('formbuilder.fatal-captcha', [error, this.$form]);
             }

--- a/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.ext.recaptcha-v3.js
+++ b/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.ext.recaptcha-v3.js
@@ -63,7 +63,11 @@
         },
 
         injectTokenToForm: function () {
-            grecaptcha.execute(this.siteKey, {action: this.action}).then(this.onTokenGenerated.bind(this));
+            try {
+                grecaptcha.execute(this.siteKey, { action: this.action }).then(this.onTokenGenerated.bind(this));
+            } catch (error) {
+                this.$form.trigger('formbuilder.fatal-captcha', [error, this.$form]);
+            }
         },
 
         /**

--- a/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.ext.recaptcha-v3.js
+++ b/src/FormBuilderBundle/Resources/public/js/frontend/plugins/jquery.fb.ext.recaptcha-v3.js
@@ -63,9 +63,11 @@
         },
 
         injectTokenToForm: function () {
+            var _this = this;
+            
             try {
-                grecaptcha.execute(this.siteKey, { action: this.action }).then(this.onTokenGenerated.bind(this), function() => {
-                    this.$form.trigger('formbuilder.fatal-captcha', [null, this.$form]);
+                grecaptcha.execute(this.siteKey, { action: this.action }).then(this.onTokenGenerated.bind(this), function() {
+                    _this.$form.trigger('formbuilder.fatal-captcha', [null, _this.$form]);
                 });
             } catch (error) {
                 this.$form.trigger('formbuilder.fatal-captcha', [error, this.$form]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | No ticket

Adds an additional event to the pimcore formbuilder form in case the execution of google reCaptcha fails, so it's possible to react to this case from outside (e.g. show visible error message).

The even then can be handled according to the following example:

```js
$('form.formbuilder.ajax-form')
  .formBuilderReCaptchaV3({ /* ... */ })
  .on('formbuilder.fatal-captcha', function(event, error, $form) {
      console.log(error)
    })
```
