### PR TITLE
ensure migration of form configs will be symfony5 compatible

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,7 @@
 #### Version 4.1.0
 - **[NEW FEATURE]**: API Output channel [#290](https://github.com/dachcom-digital/pimcore-formbuilder/issues/301)
 - **[NEW FEATURE]**: API Output channel Field Transformer
+- **[BUGFIX]**: ensure migration of form configs will be symfony5 compatible [@grizzlydotweb](https://github.com/dachcom-digital/pimcore-formbuilder/pull/310)
 
 ## Version 4.0.2
 - [ENHANCEMENT] enable placeholder in cc and bcc field in email output workflow [@frithjof](https://github.com/dachcom-digital/pimcore-formbuilder/pull/305)

--- a/src/FormBuilderBundle/Migrations/Version20211011171530.php
+++ b/src/FormBuilderBundle/Migrations/Version20211011171530.php
@@ -5,7 +5,6 @@ namespace FormBuilderBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Exception\MigrationNotExecuted;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
@@ -58,14 +57,55 @@ final class Version20211011171530 extends AbstractMigration
             $conditionalLogic = $data['conditional_logic'] ?? [];
             $fields = $data['fields'] ?? [];
 
+            $fixedFields = $this->ensureSymfony5Compatibility($fields);
+
             $this->addSql(sprintf('UPDATE formbuilder_forms SET `configuration` = "%s" WHERE `id` = %d', addslashes(serialize($configuration)), $formDefinitionId));
             $this->addSql(sprintf('UPDATE formbuilder_forms SET `conditionalLogic` = "%s" WHERE `id` = %d', addslashes(serialize($conditionalLogic)), $formDefinitionId));
-            $this->addSql(sprintf('UPDATE formbuilder_forms SET `fields` = "%s" WHERE `id` = %d', addslashes(serialize($fields)), $formDefinitionId));
+            $this->addSql(sprintf('UPDATE formbuilder_forms SET `fields` = "%s" WHERE `id` = %d', addslashes(serialize($fixedFields)), $formDefinitionId));
         }
     }
 
     public function down(Schema $schema): void
     {
         // disabled
+    }
+
+    private function ensureSymfony5Compatibility(array $fields): array
+    {
+        $fixedFields = [];
+        foreach ($fields as $field) {
+            if ($field['type'] == 'choice') {
+                $this->fixChoiceField($field);
+            }
+
+            if (isset($field['constraints'])) {
+                $this->fixConstraints($field);
+            }
+
+            $fixedFields[] = $field;
+        }
+
+        return $fixedFields;
+    }
+
+    private function fixChoiceField(array &$field)
+    {
+        if (array_key_exists('choice_attr', $field['options'])) {
+            return;
+        }
+
+        $field['options']['choice_attr'] = [];
+    }
+
+    private function fixConstraints(array &$field)
+    {
+        for ($i = 0; $i < count($field['constraints']); $i++) {
+            if ($field['constraints'][$i]['type'] !== 'email') {
+                continue;
+            }
+
+            unset($field['constraints'][$i]['config']['checkMX']);
+            unset($field['constraints'][$i]['config']['checkHost']);
+        }
     }
 }

--- a/src/FormBuilderBundle/Migrations/Version20211011171530.php
+++ b/src/FormBuilderBundle/Migrations/Version20211011171530.php
@@ -74,7 +74,7 @@ final class Version20211011171530 extends AbstractMigration
     {
         $fixedFields = [];
         foreach ($fields as $field) {
-            if ($field['type'] == 'choice') {
+            if ($field['type'] === 'choice') {
                 $this->fixChoiceField($field);
             }
 
@@ -88,7 +88,7 @@ final class Version20211011171530 extends AbstractMigration
         return $fixedFields;
     }
 
-    private function fixChoiceField(array &$field)
+    private function fixChoiceField(array &$field): void
     {
         if (array_key_exists('choice_attr', $field['options'])) {
             return;
@@ -97,15 +97,15 @@ final class Version20211011171530 extends AbstractMigration
         $field['options']['choice_attr'] = [];
     }
 
-    private function fixConstraints(array &$field)
+    private function fixConstraints(array &$field): void
     {
         for ($i = 0; $i < count($field['constraints']); $i++) {
+
             if ($field['constraints'][$i]['type'] !== 'email') {
                 continue;
             }
 
-            unset($field['constraints'][$i]['config']['checkMX']);
-            unset($field['constraints'][$i]['config']['checkHost']);
+            unset($field['constraints'][$i]['config']['checkMX'], $field['constraints'][$i]['config']['checkHost']);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

the existing form / field configurations could have old symfony options.

see:
https://symfony.com/doc/4.4/reference/constraints/Email.html#checkmx

also choice_attr has to be applied in choice field options. otherwise an exception for undefiend key will be thrown here:
https://github.com/dachcom-digital/pimcore-formbuilder/pull/276/files#diff-3c8555d2c6cc59f3d72fae793f429160b22eeb9f1ec8493b1bef727fff4286d2R818

https://github.com/dachcom-digital/pimcore-formbuilder/pull/276
