### PR TITLE
Introduce Output Workflow Signal Event

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,7 @@
 - **[NEW FEATURE]**: API Output channel [#290](https://github.com/dachcom-digital/pimcore-formbuilder/issues/301)
 - **[NEW FEATURE]**: API Output channel field transformer
 - **[BUGFIX]**: ensure migration of form configs will be symfony5 compatible [@grizzlydotweb](https://github.com/dachcom-digital/pimcore-formbuilder/pull/310)
+- **[BUGFIX]**: introduce output workflow signals: attachments not working with multiple channels [#311](https://github.com/dachcom-digital/pimcore-formbuilder/issues/311) 
 - **[BUGFIX]**: fix typo in translation [#312](https://github.com/dachcom-digital/pimcore-formbuilder/issues/312)
 - **[BUGFIX]**: disable `selectOnFocus` [#315](https://github.com/dachcom-digital/pimcore-formbuilder/issues/315)
 - **[BUGFIX]**: ⚠️ multi file upload: hidden type `_data` not in form row. touched view: `form/theme/type/dynamic_multi_file.html.twig` [#316](https://github.com/dachcom-digital/pimcore-formbuilder/issues/316) 

--- a/src/FormBuilderBundle/Event/OutputWorkflow/OutputWorkflowSignalEvent.php
+++ b/src/FormBuilderBundle/Event/OutputWorkflow/OutputWorkflowSignalEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FormBuilderBundle\Event\OutputWorkflow;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class OutputWorkflowSignalEvent extends Event
+{
+    public const NAME = 'form_builder.output_workflow.signal';
+
+    protected string $name;
+    protected mixed $data;
+
+    public function __construct(string $name, mixed $data)
+    {
+        $this->name = $name;
+        $this->data = $data;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getData(): mixed
+    {
+        return $this->data;
+    }
+}

--- a/src/FormBuilderBundle/Event/OutputWorkflow/OutputWorkflowSignalsEvent.php
+++ b/src/FormBuilderBundle/Event/OutputWorkflow/OutputWorkflowSignalsEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace FormBuilderBundle\Event\OutputWorkflow;
+
+use FormBuilderBundle\Exception\OutputWorkflow;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class OutputWorkflowSignalsEvent extends Event
+{
+    protected array $signals;
+    protected ?\Exception $exception;
+
+    public function __construct(array $signals, ?\Exception $exception)
+    {
+        $this->signals = $signals;
+        $this->exception = $exception;
+    }
+
+    public function hasException(): bool
+    {
+        return $this->exception instanceof \Exception;
+    }
+
+    public function hasGuardException(): bool
+    {
+        return $this->exception instanceof OutputWorkflow\GuardChannelException ||
+            $this->exception instanceof OutputWorkflow\GuardOutputWorkflowException ||
+            $this->exception instanceof OutputWorkflow\GuardStackedException;
+    }
+
+    public function getException(): ?\Exception
+    {
+        return $this->exception;
+    }
+
+    /**
+     * @return array<int, OutputWorkflowSignalEvent>
+     */
+    public function getAllSignals(): array
+    {
+        return $this->signals;
+    }
+
+    /**
+     * @return array<int, OutputWorkflowSignalEvent>
+     */
+    public function getSignalsByName(string $name): array
+    {
+        return array_values(
+            array_filter($this->signals, static function (OutputWorkflowSignalEvent $signal) use ($name) {
+                return $signal->getName() === $name;
+            })
+        );
+    }
+}

--- a/src/FormBuilderBundle/EventSubscriber/OutputWorkflowSignalSubscriber.php
+++ b/src/FormBuilderBundle/EventSubscriber/OutputWorkflowSignalSubscriber.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace FormBuilderBundle\EventSubscriber;
+
+use FormBuilderBundle\Event\OutputWorkflow\OutputWorkflowSignalEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class OutputWorkflowSignalSubscriber implements EventSubscriberInterface
+{
+    protected array $signals = [];
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            OutputWorkflowSignalEvent::NAME => 'addSignal',
+        ];
+    }
+
+    public function addSignal(OutputWorkflowSignalEvent $signalEvent): void
+    {
+        $this->signals[] = $signalEvent;
+    }
+
+    public function getSignals(): array
+    {
+        return $this->signals;
+    }
+}

--- a/src/FormBuilderBundle/Form/Data/FormData.php
+++ b/src/FormBuilderBundle/Form/Data/FormData.php
@@ -3,6 +3,7 @@
 namespace FormBuilderBundle\Form\Data;
 
 use FormBuilderBundle\Model\FormDefinitionInterface;
+use FormBuilderBundle\Stream\File;
 
 class FormData implements FormDataInterface
 {
@@ -32,12 +33,16 @@ class FormData implements FormDataInterface
 
     public function getAttachments(): array
     {
-        return $this->attachments;
+        return array_values($this->attachments);
     }
 
-    public function addAttachment(array $attachmentFileInfo): void
+    public function addAttachment(File $attachmentFile): void
     {
-        $this->attachments[] = $attachmentFileInfo;
+        if (array_key_exists($attachmentFile->getId(), $this->attachments)) {
+            return;
+        }
+
+        $this->attachments[$attachmentFile->getId()] = $attachmentFile;
     }
 
     public function getFieldValue(string $name): mixed

--- a/src/FormBuilderBundle/Form/Data/FormDataInterface.php
+++ b/src/FormBuilderBundle/Form/Data/FormDataInterface.php
@@ -3,6 +3,7 @@
 namespace FormBuilderBundle\Form\Data;
 
 use FormBuilderBundle\Model\FormDefinitionInterface;
+use FormBuilderBundle\Stream\File;
 
 interface FormDataInterface
 {
@@ -16,7 +17,10 @@ interface FormDataInterface
 
     public function hasAttachments(): bool;
 
+    /**
+     * @return array<int, File>
+     */
     public function getAttachments(): array;
 
-    public function addAttachment(array $attachmentFileInfo): void;
+    public function addAttachment(File $attachmentFile): void;
 }

--- a/src/FormBuilderBundle/FormBuilderEvents.php
+++ b/src/FormBuilderBundle/FormBuilderEvents.php
@@ -52,4 +52,9 @@ final class FormBuilderEvents
      * @see \FormBuilderBundle\Event\OutputWorkflow\ChannelSubjectGuardEvent
      */
     public const OUTPUT_WORKFLOW_GUARD_SUBJECT_PRE_DISPATCH = 'form_builder.output_workflow.guard.subject.pre_dispatch';
+
+    /**
+     * @see \FormBuilderBundle\Event\OutputWorkflow\OutputWorkflowSignalsEvent
+     */
+    public const OUTPUT_WORKFLOW_SIGNALS = 'form_builder.output_workflow.signals';
 }

--- a/src/FormBuilderBundle/OutputWorkflow/Channel/Email/EmailOutputChannel.php
+++ b/src/FormBuilderBundle/OutputWorkflow/Channel/Email/EmailOutputChannel.php
@@ -28,11 +28,10 @@ class EmailOutputChannel implements ChannelInterface
         return true;
     }
 
-    /**
-     * Currently unsupported for EmailOutputChanel.
-     */
     public function getUsedFormFieldNames(array $channelConfiguration): array
     {
+        // Unsupported for EmailOutputChanel
+
         return [];
     }
 

--- a/src/FormBuilderBundle/OutputWorkflow/Channel/Email/Parser/MailParser.php
+++ b/src/FormBuilderBundle/OutputWorkflow/Channel/Email/Parser/MailParser.php
@@ -2,6 +2,7 @@
 
 namespace FormBuilderBundle\OutputWorkflow\Channel\Email\Parser;
 
+use FormBuilderBundle\Stream\File;
 use Pimcore\Mail;
 use Pimcore\Model\Document\Email;
 use Symfony\Component\Form\FormInterface;
@@ -9,7 +10,6 @@ use Symfony\Component\Templating\EngineInterface;
 use FormBuilderBundle\Form\Data\FormDataInterface;
 use FormBuilderBundle\Form\FormValuesOutputApplierInterface;
 use FormBuilderBundle\MailEditor\Parser\PlaceholderParserInterface;
-use FormBuilderBundle\Stream\AttachmentStreamInterface;
 
 class MailParser
 {
@@ -17,18 +17,15 @@ class MailParser
     protected Email $mailTemplate;
     protected FormValuesOutputApplierInterface $formValuesOutputApplier;
     protected PlaceholderParserInterface $placeholderParser;
-    protected AttachmentStreamInterface $attachmentStream;
 
     public function __construct(
         EngineInterface $templating,
         FormValuesOutputApplierInterface $formValuesOutputApplier,
-        PlaceholderParserInterface $placeholderParser,
-        AttachmentStreamInterface $attachmentStream
+        PlaceholderParserInterface $placeholderParser
     ) {
         $this->templating = $templating;
         $this->formValuesOutputApplier = $formValuesOutputApplier;
         $this->placeholderParser = $placeholderParser;
-        $this->attachmentStream = $attachmentStream;
     }
 
     /**
@@ -154,14 +151,13 @@ class MailParser
 
     protected function parseMailAttachment(Mail $mail, array $attachments): void
     {
-        foreach ($attachments as $attachmentFileInfo) {
+        /** @var File $attachmentFile */
+        foreach ($attachments as $attachmentFile) {
             try {
-                $mail->attach(file_get_contents($attachmentFileInfo['path']), $attachmentFileInfo['name']);
+                $mail->attach(file_get_contents($attachmentFile->getPath()), $attachmentFile->getName());
             } catch (\Exception $e) {
                 // fail silently.
             }
-
-            $this->attachmentStream->removeAttachmentByFileInfo($attachmentFileInfo);
         }
     }
 

--- a/src/FormBuilderBundle/OutputWorkflow/OutputWorkflowDispatcher.php
+++ b/src/FormBuilderBundle/OutputWorkflow/OutputWorkflowDispatcher.php
@@ -53,7 +53,7 @@ class OutputWorkflowDispatcher implements OutputWorkflowDispatcherInterface
                         $outputWorkflow->getName(),
                         $channel->getType(),
                         $index + 1,
-                        $e->getMessage() . ' ' . $e->getFile() . ' ' . $e->getLine()
+                        $e->getMessage()
                     )
                 );
             }

--- a/src/FormBuilderBundle/OutputWorkflow/OutputWorkflowDispatcher.php
+++ b/src/FormBuilderBundle/OutputWorkflow/OutputWorkflowDispatcher.php
@@ -3,23 +3,33 @@
 namespace FormBuilderBundle\OutputWorkflow;
 
 use FormBuilderBundle\Event\SubmissionEvent;
+use FormBuilderBundle\Event\OutputWorkflow\OutputWorkflowSignalsEvent;
+use FormBuilderBundle\EventSubscriber\OutputWorkflowSignalSubscriber;
 use FormBuilderBundle\Exception\OutputWorkflow\GuardChannelException;
 use FormBuilderBundle\Exception\OutputWorkflow\GuardOutputWorkflowException;
 use FormBuilderBundle\Exception\OutputWorkflow\GuardStackedException;
+use FormBuilderBundle\FormBuilderEvents;
 use FormBuilderBundle\Model\OutputWorkflowInterface;
 use FormBuilderBundle\Registry\OutputWorkflowChannelRegistry;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class OutputWorkflowDispatcher implements OutputWorkflowDispatcherInterface
 {
+    protected EventDispatcherInterface $eventDispatcher;
     protected OutputWorkflowChannelRegistry $channelRegistry;
+    protected OutputWorkflowSignalSubscriber $subscriber;
 
-    public function __construct(OutputWorkflowChannelRegistry $channelRegistry)
+    public function __construct(EventDispatcherInterface $eventDispatcher, OutputWorkflowChannelRegistry $channelRegistry)
     {
+        $this->eventDispatcher = $eventDispatcher;
         $this->channelRegistry = $channelRegistry;
     }
 
     public function dispatch(OutputWorkflowInterface $outputWorkflow, SubmissionEvent $submissionEvent): void
     {
+        $this->subscriber = new OutputWorkflowSignalSubscriber();
+        $this->eventDispatcher->addSubscriber($this->subscriber);
+
         $exceptionStack = [];
         foreach ($outputWorkflow->getChannels() as $index => $channel) {
             try {
@@ -28,22 +38,42 @@ class OutputWorkflowDispatcher implements OutputWorkflowDispatcherInterface
             } catch (GuardChannelException $e) {
                 $exceptionStack[] = $e;
             } catch (GuardOutputWorkflowException $e) {
+
+                $this->dispatchSignalsEvent($e);
+
                 throw $e;
+
             } catch (\Throwable $e) {
+
+                $this->dispatchSignalsEvent($e);
+
                 throw new \Exception(
                     sprintf(
                         '"%s" workflow channel "%s" errored at step %d: %s',
                         $outputWorkflow->getName(),
                         $channel->getType(),
                         $index + 1,
-                        $e->getMessage()
+                        $e->getMessage() . ' ' . $e->getFile() . ' ' . $e->getLine()
                     )
                 );
             }
         }
 
         if (count($exceptionStack) > 0) {
-            throw new GuardStackedException($exceptionStack);
+
+            $exception = new GuardStackedException($exceptionStack);
+            $this->dispatchSignalsEvent($exception);
+
+            throw $exception;
         }
+
+        $this->dispatchSignalsEvent();
+    }
+
+    protected function dispatchSignalsEvent(?\Exception $exception = null): void
+    {
+        $signals = $this->subscriber->getSignals();
+        $this->eventDispatcher->removeSubscriber($this->subscriber);
+        $this->eventDispatcher->dispatch(new OutputWorkflowSignalsEvent($signals, $exception), FormBuilderEvents::OUTPUT_WORKFLOW_SIGNALS);
     }
 }

--- a/src/FormBuilderBundle/Resources/config/services/stream.yml
+++ b/src/FormBuilderBundle/Resources/config/services/stream.yml
@@ -11,4 +11,6 @@ services:
 
      # stream: attachment
     FormBuilderBundle\Stream\AttachmentStreamInterface: '@FormBuilderBundle\Stream\AttachmentStream'
-    FormBuilderBundle\Stream\AttachmentStream: ~
+    FormBuilderBundle\Stream\AttachmentStream:
+        tags:
+            - { name: kernel.event_listener, event: !php/const FormBuilderBundle\FormBuilderEvents::OUTPUT_WORKFLOW_SIGNALS, method: cleanUp }

--- a/src/FormBuilderBundle/Stream/AttachmentStream.php
+++ b/src/FormBuilderBundle/Stream/AttachmentStream.php
@@ -2,29 +2,34 @@
 
 namespace FormBuilderBundle\Stream;
 
+use Doctrine\DBAL\Query\QueryBuilder;
+use FormBuilderBundle\Event\OutputWorkflow\OutputWorkflowSignalEvent;
+use FormBuilderBundle\Event\OutputWorkflow\OutputWorkflowSignalsEvent;
 use FormBuilderBundle\Tool\FileLocator;
-use Pimcore\File;
 use Pimcore\Logger;
 use Pimcore\Model\Asset;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class AttachmentStream implements AttachmentStreamInterface
 {
+    protected const PACKAGE_IDENTIFIER = 'formbuilder_package_identifier';
+    protected const SIGNAL_CLEAN_UP = 'tmp_file_attachment_stream';
+
+    protected EventDispatcherInterface $eventDispatcher;
     protected FileLocator $fileLocator;
 
-    public function __construct(FileLocator $fileLocator)
+    public function __construct(EventDispatcherInterface $eventDispatcher, FileLocator $fileLocator)
     {
+        $this->eventDispatcher = $eventDispatcher;
         $this->fileLocator = $fileLocator;
     }
 
+    /**
+     * @return array<int, File>
+     */
     public function createAttachmentLinks(array $data, string $formName): array
     {
-        $files = $this->extractFiles($data);
-
-        if (empty($files)) {
-            return [];
-        }
-
-        return $files;
+        return $this->extractFiles($data);
     }
 
     public function createAttachmentAsset($data, $fieldName, $formName): ?Asset
@@ -35,42 +40,51 @@ class AttachmentStream implements AttachmentStreamInterface
 
         $files = $this->extractFiles($data);
 
-        if (empty($files)) {
+        if (count($files) === 0) {
             return null;
         }
 
-        $key = substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyz'), 0, 5);
-        $zipFileName = File::getValidFilename($fieldName) . '-' . $key . '.zip';
-        $zipPath = $this->fileLocator->getZipFolder() . '/' . $zipFileName;
+        $packageIdentifier = '';
+        foreach ($files as $file) {
+            $packageIdentifier .= sprintf('%s-%s-%s-%s', filesize($file->getPath()), $file->getId(), $file->getPath(), $file->getName());
+        }
+
+        // create package identifier to check if we just in another channel
+        $packageIdentifier = md5($packageIdentifier);
+
+        $formName = \Pimcore\File::getValidFilename($formName);
+        $zipKey = substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyz'), 0, 5);
+        $zipFileName = sprintf('%s-%s.zip', \Pimcore\File::getValidFilename($fieldName), $zipKey);
+        $zipPath = sprintf('%s/%s', $this->fileLocator->getZipFolder(), $zipFileName);
+
+        $existingAssetPackage = $this->findExistingAssetPackage($packageIdentifier, $formName);
+
+        if ($existingAssetPackage instanceof Asset) {
+            return $existingAssetPackage;
+        }
 
         try {
             $zip = new \ZipArchive();
             $zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
 
-            foreach ($files as $fileInfo) {
-                $zip->addFile($fileInfo['path'], $fileInfo['name']);
+            foreach ($files as $file) {
+                $zip->addFile($file->getPath(), $file->getName());
             }
 
             $zip->close();
 
-            //clean up!
-            foreach ($files as $fileInfo) {
-                $this->removeAttachmentByFileInfo($fileInfo);
-            }
         } catch (\Exception $e) {
-            echo $e->getMessage();
-            Logger::log('Error while creating zip for FormBuilder (' . $zipPath . '): ' . $e->getMessage());
+            Logger::error(sprintf('Error while creating attachment zip (%s): %s', $zipPath, $e->getMessage()));
 
             return null;
         }
 
         if (!file_exists($zipPath)) {
-            Logger::log('zip path does not exist (' . $zipPath . ')');
+            Logger::error(sprintf('zip path does not exist (%s)', $zipPath));
 
             return null;
         }
 
-        $formDataFolder = null;
         $formDataParentFolder = Asset\Folder::getByPath('/formdata');
 
         if (!$formDataParentFolder instanceof Asset\Folder) {
@@ -79,8 +93,7 @@ class AttachmentStream implements AttachmentStreamInterface
             return null;
         }
 
-        $formName = File::getValidFilename($formName);
-        $formFolderExists = Asset\Service::pathExists('/formdata/' . $formName);
+        $formFolderExists = Asset\Service::pathExists(sprintf('/formdata/%s', $formName));
 
         if ($formFolderExists === false) {
             $formDataFolder = new Asset\Folder();
@@ -97,11 +110,11 @@ class AttachmentStream implements AttachmentStreamInterface
                 // fail silently.
             }
         } else {
-            $formDataFolder = Asset\Folder::getByPath('/formdata/' . $formName);
+            $formDataFolder = Asset\Folder::getByPath(sprintf('/formdata/%s', $formName));
         }
 
         if (!$formDataFolder instanceof Asset\Folder) {
-            Logger::error('Error while creating formDataFolder: (/formdata/' . $formName . ')');
+            Logger::error(sprintf('Error while creating form data folder (/formdata/%s)', $formName));
 
             return null;
         }
@@ -113,12 +126,13 @@ class AttachmentStream implements AttachmentStreamInterface
 
         try {
             $asset = Asset::create($formDataFolder->getId(), $assetData, false);
+            $asset->setProperty(self::PACKAGE_IDENTIFIER, 'text', $packageIdentifier, false, false);
             $asset->save();
             if (file_exists($zipPath)) {
                 unlink($zipPath);
             }
         } catch (\Exception $e) {
-            Logger::log('Error while storing asset in Pimcore (' . $zipPath . '): ' . $e->getMessage());
+            Logger::error(sprintf('Error while storing asset in pimcore (%s): %s', $zipPath, $e->getMessage()));
 
             return null;
         }
@@ -126,10 +140,29 @@ class AttachmentStream implements AttachmentStreamInterface
         return $asset;
     }
 
-    public function removeAttachmentByFileInfo(array $fileInfo): void
+    /**
+     * @internal
+     */
+    public function cleanUp(OutputWorkflowSignalsEvent $signalsEvent): void
+    {
+        // keep assets if guard exception occurs: use may want to retry!
+
+        if ($signalsEvent->hasGuardException() === true) {
+            return;
+        }
+
+        foreach ($signalsEvent->getSignalsByName(self::SIGNAL_CLEAN_UP) as $signal) {
+            /** @var File $attachmentFile */
+            foreach ($signal->getData() as $attachmentFile) {
+                $this->removeAttachmentFile($attachmentFile);
+            }
+        }
+    }
+
+    protected function removeAttachmentFile(File $attachmentFile): void
     {
         $targetFolder = $this->fileLocator->getFilesFolder();
-        $target = implode(DIRECTORY_SEPARATOR, [$targetFolder, $fileInfo['id']]);
+        $target = implode(DIRECTORY_SEPARATOR, [$targetFolder, $attachmentFile->getId()]);
 
         if (!is_dir($target)) {
             return;
@@ -138,23 +171,56 @@ class AttachmentStream implements AttachmentStreamInterface
         $this->fileLocator->removeDir($target);
     }
 
+    /**
+     * @return array<int, File>
+     */
     protected function extractFiles(array $data): array
     {
         $files = [];
         foreach ($data as $fileData) {
-            $fileDir = $this->fileLocator->getFilesFolder() . '/' . $fileData['id'];
+
+            $fileId = (string) $fileData['id'];
+            $fileDir = sprintf('%s/%s', $this->fileLocator->getFilesFolder(), $fileId);
+
             if (is_dir($fileDir)) {
                 $dirFiles = glob($fileDir . '/*');
                 if (count($dirFiles) === 1) {
-                    $files[] = [
-                        'name' => $fileData['fileName'],
-                        'id'   => $fileData['id'],
-                        'path' => $dirFiles[0]
-                    ];
+                    $files[] = new File($fileId, $fileData['fileName'], $dirFiles[0]);
                 }
             }
         }
 
+        // add signal for later clean up
+        $this->eventDispatcher->dispatch(
+            new OutputWorkflowSignalEvent(self::SIGNAL_CLEAN_UP, $files),
+            OutputWorkflowSignalEvent::NAME
+        );
+
         return $files;
+    }
+
+    protected function findExistingAssetPackage(string $packageIdentifier, string $formName): ?Asset
+    {
+        $assetListing = new Asset\Listing();
+        $assetListing->addConditionParam('`assets`.path = ?', sprintf('/formdata/%s/', $formName));
+        $assetListing->addConditionParam('`properties`.data = ?', $packageIdentifier);
+        $assetListing->setLimit(1);
+
+        $assetListing->onCreateQueryBuilder(function (QueryBuilder $queryBuilder) {
+            $queryBuilder->leftJoin(
+                'assets',
+                'properties',
+                'properties',
+                sprintf('properties.`cid` = assets.`id` AND properties.`name` = "%s"', self::PACKAGE_IDENTIFIER)
+            );
+        });
+
+        $assets = $assetListing->getAssets();
+
+        if (count($assets) === 0) {
+            return null;
+        }
+
+        return $assets[0];
     }
 }

--- a/src/FormBuilderBundle/Stream/AttachmentStreamInterface.php
+++ b/src/FormBuilderBundle/Stream/AttachmentStreamInterface.php
@@ -9,6 +9,4 @@ interface AttachmentStreamInterface
     public function createAttachmentAsset(array $data, string $fieldName, string $formName): ?Asset;
 
     public function createAttachmentLinks(array $data, string $formName): array;
-
-    public function removeAttachmentByFileInfo(array $fileInfo): void;
 }

--- a/src/FormBuilderBundle/Stream/File.php
+++ b/src/FormBuilderBundle/Stream/File.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace FormBuilderBundle\Stream;
+
+class File
+{
+    protected string $id;
+    protected string $name;
+    protected string $path;
+
+    public function __construct(string $id, string $name, string $path)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->path = $path;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+}

--- a/src/FormBuilderBundle/Transformer/Output/DynamicMultiFileTransformer.php
+++ b/src/FormBuilderBundle/Transformer/Output/DynamicMultiFileTransformer.php
@@ -35,8 +35,8 @@ class DynamicMultiFileTransformer implements OutputTransformerInterface
 
         if (isset($options['submit_as_attachment']) && $options['submit_as_attachment'] === true) {
             $attachmentLinks = $this->attachmentStream->createAttachmentLinks($attachmentData, $fieldDefinition->getName());
-            foreach ($attachmentLinks as $attachmentLink) {
-                $rootFormData->addAttachment($attachmentLink);
+            foreach ($attachmentLinks as $attachment) {
+                $rootFormData->addAttachment($attachment);
             }
 
             // attachment is not required to get displayed in mail body


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #311

This PR introduces an internal `OutputWorkflowSignalsEvent` which triggers after every output workflow has finished. During the output workflow runtime, this event collects "signal events" which can be processed after all channels have been processed. 

For example, if you're using an attachment field for multiple channels, the temp files are gone after dispatching the first channel. We need to wait, until the output workflow has been shutdown. This PR allows us to wait with assets clean up until the submission has finished.
