### PR TITLE
Explicitly render twig email template

### DIFF
--- a/src/FormBuilderBundle/Controller/EmailController.php
+++ b/src/FormBuilderBundle/Controller/EmailController.php
@@ -8,5 +8,6 @@ class EmailController extends FrontendController
 {
     public function emailAction()
     {
+        return $this->renderTemplate('@FormBuilder/Email/email.html.twig');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This line enables you to overwrite the email template with your own Twig template. Otherwise you get en error that the `email.html.php` file was not found and for obvious reasons (😉) I do not want to use PHP template files.