### PR TITLE
delete unnecessary line to prevent out of memory issues.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+#### Update to Version 4.1.2
+- **[BUGFIX]**: Email CSV export: delete unnecessary line to prevent out of memory issues. [#328](https://github.com/dachcom-digital/pimcore-formbuilder/pull/328)
+
 ## Version 4.1.1
 - **[BUGFIX]**: Fix legacy fine uploader identifier
 

--- a/src/FormBuilderBundle/Controller/Admin/ExportController.php
+++ b/src/FormBuilderBundle/Controller/Admin/ExportController.php
@@ -101,8 +101,6 @@ class ExportController extends AdminController
             $emailLogs->addConditionParam('params LIKE ?', sprintf('%%%s%%', $this->generateOutputWorkflowFilterQuery($formId, (int) $filter)));
         }
 
-        $this->buildCsv($emailLogs->getEmailLogs(), $formId);
-
         $response = new Response();
         $response->headers->set('Content-Encoding', 'none');
         $response->headers->set('Content-Type', 'text/csv; charset=UTF-8');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Email CSV export: delete unnecessary line to prevent out of memory issues.
