### PR TITLE
ConditionalLogic: Load Formdata from Containerfields

### DIFF
--- a/src/FormBuilderBundle/EventSubscriber/FormBuilderSubscriber.php
+++ b/src/FormBuilderBundle/EventSubscriber/FormBuilderSubscriber.php
@@ -131,8 +131,7 @@ class FormBuilderSubscriber implements EventSubscriberInterface
                 $formTypeData = $this->addDynamicField($field);
                 $form->add($formTypeData['name'], $formTypeData['type'], $formTypeData['options']);
             } elseif ($field instanceof FormFieldContainerDefinitionInterface) {
-                $subFieldData = isset($data[$field->getName()]) ? $data[$field->getName()] : [];
-                $conditionalLogicOptions = array_merge(['formData' => $subFieldData, 'field' => null], $conditionalLogicBaseOptions);
+                $conditionalLogicOptions = array_merge(['formData' => $data, 'field' => null], $conditionalLogicBaseOptions);
                 $formTypeData = $this->addFormBuilderContainerField($field, $conditionalLogicOptions);
                 $form->add($formTypeData['name'], $formTypeData['type'], $formTypeData['options']);
             } else {

--- a/src/FormBuilderBundle/Validation/ConditionalLogic/Rule/Condition/ElementValueCondition.php
+++ b/src/FormBuilderBundle/Validation/ConditionalLogic/Rule/Condition/ElementValueCondition.php
@@ -15,7 +15,7 @@ class ElementValueCondition implements ConditionInterface
     public function isValid(array $formData, int $ruleId, array $configuration = []): bool
     {
         foreach ($this->getFields() as $conditionFieldName) {
-            $fieldValue = $formData[$conditionFieldName] ?? null;
+            $fieldValue = $this->getFieldValue($formData, $conditionFieldName);
 
             if ($this->getComparator() === 'contains') {
                 $value = is_array($this->getValue()) ? $this->getValue() : (is_string($this->getValue()) ? explode(',', $this->getValue()) : [$this->getValue()]);
@@ -54,6 +54,27 @@ class ElementValueCondition implements ConditionInterface
         }
 
         return false;
+    }
+
+    protected function getFieldValue(array $formData, string $fieldname) {
+        $fieldValue = $formData[$fieldname] ?? null;
+        if ($fieldValue !== null) {
+            return $fieldValue;
+        }
+
+        $containers = array_filter($formData, static function ($data) {
+            return is_array($data) && !empty($data);
+        });
+
+        // iterate over container data until field is found
+        foreach ($containers as $container) {
+            $fieldValue = $this->getFieldValue($container, $fieldname);
+            if ($fieldValue !== null) {
+                break;
+            }
+        }
+
+        return $fieldValue;
     }
 
     public function getComparator(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

ConditonalLogic Actions are ignored when "Element Value" field is in a container. 
Steps to reproduce:
- create form with 2 fields in fieldset container
- create conditional logic, if field_1 is not value "something", remove validation from field_2

The Validation is always removed, even if element value condition is not met.

Example Form export: https://gist.github.com/JHeimbach/f17b9b6efded6767396c973f796d4985

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
