### PR TITLE
Allow empty Validation field when removeAllValidations is checked

### DIFF
--- a/src/FormBuilderBundle/Resources/public/js/extjs/conditional-logic/action/constraintsRemove.js
+++ b/src/FormBuilderBundle/Resources/public/js/extjs/conditional-logic/action/constraintsRemove.js
@@ -91,6 +91,7 @@ Formbuilder.extjs.conditionalLogic.action.constraintsRemove = Class.create(Formb
                         },
                         change: function (e) {
                             validationSelectionField.setDisabled(this.checked);
+                            validationSelectionField.allowBlank = this.checked;
                             if (this.checked) {
                                 validationSelectionField.clearValue();
                             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Current behavior:  
The Conditional Logic Action "Remove Validation" has a checkbox "Remove all Validations",  if this checkbox is checked, we get an validationerror on save:
 
![scrnli_5_3_2022_3-00-10 PM](https://user-images.githubusercontent.com/1742040/166458333-e825bc06-6fd7-4d43-96c5-e1eaac367347.png)

This PR fixes this issue and removeAllValidation can be checked and saved.


<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
