### PR TITLE
Pimcore 10.5

### DIFF
--- a/src/FormBuilderBundle/Controller/Admin/MailEditorController.php
+++ b/src/FormBuilderBundle/Controller/Admin/MailEditorController.php
@@ -5,140 +5,35 @@ namespace FormBuilderBundle\Controller\Admin;
 use FormBuilderBundle\Builder\ExtJsFormBuilder;
 use FormBuilderBundle\MailEditor\Widget\MailEditorFieldDataWidgetInterface;
 use FormBuilderBundle\Manager\FormDefinitionManager;
-use FormBuilderBundle\Model\FormDefinitionInterface;
 use FormBuilderBundle\Model\Fragment\EntityToArrayAwareInterface;
 use FormBuilderBundle\Registry\MailEditorWidgetRegistry;
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
+use Pimcore\Translation\Translator;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class MailEditorController extends AdminController
 {
-    /**
-     * @var MailEditorWidgetRegistry
-     */
-    protected $mailEditorWidgetRegistry;
+    protected MailEditorWidgetRegistry $mailEditorWidgetRegistry;
+    protected FormDefinitionManager $formDefinitionManager;
+    protected ExtJsFormBuilder $extJsFormBuilder;
+    protected Translator $translation;
 
-    /**
-     * @var FormDefinitionManager
-     */
-    protected $formDefinitionManager;
-
-    /**
-     * @var ExtJsFormBuilder
-     */
-    protected $extJsFormBuilder;
-
-    /**
-     * @var TranslatorInterface
-     */
-    protected $translator;
-
-    /**
-     * @param MailEditorWidgetRegistry $mailEditorWidgetRegistry
-     * @param FormDefinitionManager    $formDefinitionManager
-     * @param ExtJsFormBuilder         $extJsFormBuilder
-     * @param TranslatorInterface      $translator
-     */
     public function __construct(
         MailEditorWidgetRegistry $mailEditorWidgetRegistry,
         FormDefinitionManager $formDefinitionManager,
         ExtJsFormBuilder $extJsFormBuilder,
-        TranslatorInterface $translator
+        Translator $translation
     ) {
         $this->mailEditorWidgetRegistry = $mailEditorWidgetRegistry;
         $this->formDefinitionManager = $formDefinitionManager;
         $this->extJsFormBuilder = $extJsFormBuilder;
-        $this->translator = $translator;
+        $this->translation = $translation;
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return JsonResponse
-     */
-    public function getMailEditorAvailableMailTypesAction(Request $request)
+    public function getMailEditorDataAction(Request $request): JsonResponse
     {
         $formId = $request->get('id');
-
-        $formDefinition = $this->formDefinitionManager->getById($formId);
-
-        if (!$formDefinition instanceof FormDefinitionInterface) {
-            return $this->json(['success' => false, 'message' => 'form is not available']);
-        }
-
-        $mailLayouts = $formDefinition->getMailLayout();
-
-        $availableTypes = [];
-        foreach (['main', 'copy'] as $validType) {
-            $availableTypes[] =
-                [
-                    'identifier'  => $validType,
-                    'isAvailable' => isset($mailLayouts[$validType])
-                ];
-        }
-
-        return $this->json(['success' => true, 'types' => $availableTypes]);
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return JsonResponse
-     */
-    public function deleteMailEditorMailTypeAction(Request $request)
-    {
-        $success = true;
-        $message = null;
-
-        $formId = $request->get('id');
-        $mailType = $request->get('mailType');
-
-        $formDefinition = $this->formDefinitionManager->getById($formId);
-
-        if (!$formDefinition instanceof FormDefinitionInterface) {
-            return $this->json(['success' => false, 'message' => 'form is not available']);
-        }
-
-        $mailLayout = $formDefinition->getMailLayout();
-
-        if (!isset($mailLayout[$mailType])) {
-            return $this->json(['success' => false, 'message' => sprintf('mailtype %s is not available', $mailType)]);
-        }
-
-        unset($mailLayout[$mailType]);
-
-        $mailLayout = $this->cleanupMailLayout($mailLayout);
-
-        $formDefinition->setMailLayout(count($mailLayout) === 0 ? null : $mailLayout);
-
-        try {
-            $this->formDefinitionManager->saveRawEntity($formDefinition);
-        } catch (\Exception $e) {
-            $success = false;
-            $message = sprintf('Error while saving form mail layout with id %d. Error was: %s', $formId, $e->getMessage());
-        }
-
-        return $this->json([
-            'formId'  => (int) $formId,
-            'success' => $success,
-            'message' => $message
-        ]);
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return JsonResponse
-     *
-     * @throws \Exception
-     */
-    public function getMailEditorDataAction(Request $request)
-    {
-        $formId = $request->get('id');
-        $mailType = $request->get('mailType');
-        $externalData = $request->get('externalData', 'false');
 
         $formDefinition = $this->formDefinitionManager->getById($formId);
 
@@ -161,7 +56,7 @@ class MailEditorController extends AdminController
 
             if (!isset($allWidgets[$groupName])) {
                 $allWidgets[$groupName] = [
-                    'label'    => $this->translator->trans($groupName, [], 'admin'),
+                    'label'    => $this->translation->trans($groupName, [], 'admin'),
                     'elements' => []
                 ];
             }
@@ -182,7 +77,7 @@ class MailEditorController extends AdminController
                 $allWidgets[$groupName]['elements'][] = [
                     'type'             => $widgetType,
                     'subType'          => null,
-                    'label'            => $this->translator->trans($widget->getWidgetLabel(), [], 'admin'),
+                    'label'            => $this->translation->trans($widget->getWidgetLabel(), [], 'admin'),
                     'configIdentifier' => $widgetType,
                 ];
             }
@@ -199,74 +94,13 @@ class MailEditorController extends AdminController
             ]
         ];
 
-        if ($externalData === 'false') {
-            $mailLayouts = $formDefinition->getMailLayout();
-            $data['data'] = isset($mailLayouts[$mailType]) ? $mailLayouts[$mailType] : null;
-        }
-
         return $this->json($data);
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return JsonResponse
-     */
-    public function saveFormMailEditorDataAction(Request $request)
-    {
-        $success = true;
-        $message = '';
-
-        $formId = $request->get('id');
-        $mailType = $request->get('mailType');
-
-        $mailLayouts = json_decode($request->get('data'), true);
-
-        $formDefinition = $this->formDefinitionManager->getById($formId);
-
-        if ($formDefinition->hasOutputWorkflows()) {
-            return $this->json([
-                'formId'  => (int) $formId,
-                'success' => false,
-                'message' => 'You cannot use the global mail editor because this form already has some configured output workflows.'
-            ]);
-        }
-
-        $storedMailLayout = is_array($formDefinition->getMailLayout()) ? $formDefinition->getMailLayout() : [];
-
-        foreach ($mailLayouts as $locale => $mailLayout) {
-            $mailLayout = str_replace('&nbsp;', ' ', $mailLayout);
-            $mailLayout = preg_replace('/\s+/', ' ', $mailLayout);
-            $storedMailLayout[$mailType][$locale] = $mailLayout;
-        }
-
-        $storedMailLayout = $this->cleanupMailLayout($storedMailLayout);
-
-        $formDefinition->setMailLayout(count($storedMailLayout) === 0 ? null : $storedMailLayout);
-
-        try {
-            $this->formDefinitionManager->saveRawEntity($formDefinition);
-        } catch (\Exception $e) {
-            $success = false;
-            $message = sprintf('Error while saving form mail layout with id %d. Error was: %s', $formId, $e->getMessage());
-        }
-
-        return $this->json([
-            'formId'  => (int) $formId,
-            'success' => $success,
-            'message' => $message
-        ]);
-    }
-
-    /**
-     * @param array $mailLayout
-     *
-     * @return array
-     */
-    protected function cleanupMailLayout(array $mailLayout)
+    protected function cleanupMailLayout(array $mailLayout): array
     {
         foreach ($mailLayout as $mailType => $layout) {
-            $mailLayout[$mailType] = array_filter($layout, function ($localizedLayout) {
+            $mailLayout[$mailType] = array_filter($layout, static function ($localizedLayout) {
                 return !empty($localizedLayout);
             });
 
@@ -278,15 +112,10 @@ class MailEditorController extends AdminController
         return $mailLayout;
     }
 
-    /**
-     * @param array $config
-     *
-     * @return array
-     */
-    protected function translateWidgetConfig(array $config)
+    protected function translateWidgetConfig(array $config): array
     {
         foreach ($config as $index => $element) {
-            $config[$index]['label'] = $this->translator->trans($element['label'], [], 'admin');
+            $config[$index]['label'] = $this->translation->trans($element['label'], [], 'admin');
         }
 
         return $config;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

Variable $translator is already defined by parent controller and cannot be re-defined. Parent Controller get's it via autowiring somehow, so better safe to just rename the var.
