### PR TITLE
Bugfix: renamed overridden $translator

### DIFF
--- a/src/FormBuilderBundle/Controller/Admin/MailEditorController.php
+++ b/src/FormBuilderBundle/Controller/Admin/MailEditorController.php
@@ -17,7 +17,7 @@ class MailEditorController extends AdminController
     protected MailEditorWidgetRegistry $mailEditorWidgetRegistry;
     protected FormDefinitionManager $formDefinitionManager;
     protected ExtJsFormBuilder $extJsFormBuilder;
-    protected Translator $translator;
+    protected Translator $pimcoreTranslator;
 
     public function __construct(
         MailEditorWidgetRegistry $mailEditorWidgetRegistry,
@@ -28,7 +28,7 @@ class MailEditorController extends AdminController
         $this->mailEditorWidgetRegistry = $mailEditorWidgetRegistry;
         $this->formDefinitionManager = $formDefinitionManager;
         $this->extJsFormBuilder = $extJsFormBuilder;
-        $this->translator = $translator;
+        $this->pimcoreTranslator = $translator;
     }
 
     public function getMailEditorDataAction(Request $request): JsonResponse
@@ -56,7 +56,7 @@ class MailEditorController extends AdminController
 
             if (!isset($allWidgets[$groupName])) {
                 $allWidgets[$groupName] = [
-                    'label'    => $this->translator->trans($groupName, [], 'admin'),
+                    'label'    => $this->pimcoreTranslator->trans($groupName, [], 'admin'),
                     'elements' => []
                 ];
             }
@@ -77,7 +77,7 @@ class MailEditorController extends AdminController
                 $allWidgets[$groupName]['elements'][] = [
                     'type'             => $widgetType,
                     'subType'          => null,
-                    'label'            => $this->translator->trans($widget->getWidgetLabel(), [], 'admin'),
+                    'label'            => $this->pimcoreTranslator->trans($widget->getWidgetLabel(), [], 'admin'),
                     'configIdentifier' => $widgetType,
                 ];
             }
@@ -115,7 +115,7 @@ class MailEditorController extends AdminController
     protected function translateWidgetConfig(array $config): array
     {
         foreach ($config as $index => $element) {
-            $config[$index]['label'] = $this->translator->trans($element['label'], [], 'admin');
+            $config[$index]['label'] = $this->pimcoreTranslator->trans($element['label'], [], 'admin');
         }
 
         return $config;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Pimcore 10.5 adds a $translator property to the extended AdminController. This is a breaking change.
The 2 variables are compatible, but I wanted to maintain backwards compatibility, so I only renamed the property instead of removing it.

![Bildschirmfoto 2022-07-27 um 18 05 31](https://user-images.githubusercontent.com/67763683/181469576-c1b9b8a4-e529-45b5-8599-889815de6dcd.png)
