### PR TITLE
Fix #366 ignoreFields Assignment for 3.x

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,9 @@
 After every update you should check the pimcore extension manager. 
 Just click the "update" button or execute the migration command to finish the bundle update.
 
+#### Update to Version 3.5.5
+- **[BUGFIX]**: Fix `ignoreFields` Assignment: Use `CollectionType` instead of `ChoiceType` 3.x [#366](https://github.com/dachcom-digital/pimcore-formbuilder/issues/366)
+
 #### Update to Version 3.5.4
 - **[ENHANCEMENT]**: Add `role="presentation"` to honeypot. [#333](https://github.com/dachcom-digital/pimcore-formbuilder/issues/333)
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.5.5
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #366 

Fix `ignoreFields` Assignment: Use `CollectionType` instead of `ChoiceType` for 3.x
Fixed in 4.x: #352 