### PR TITLE
Assert valid timezone in date time fallback output transformer

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## Version 4.3.2
+- **[BUGFIX]**: Assert valid timezone in date time fallback output transformer
+
 ## Version 4.3.1
 - **[BUGFIX]**: Fix field collection assignment [#375](https://github.com/dachcom-digital/pimcore-formbuilder/issues/375)
 

--- a/src/FormBuilderBundle/Transformer/Output/FallbackTransformer.php
+++ b/src/FormBuilderBundle/Transformer/Output/FallbackTransformer.php
@@ -114,7 +114,7 @@ class FallbackTransformer implements OutputTransformerInterface
             $locale,
             $formatValues[$dateFormat],
             $formatValues[$timeFormat],
-            $value->getTimezone() === false ? null : $value->getTimezone(),
+            $value->getTimezone(),
             \IntlDateFormatter::GREGORIAN, // @todo: allow different formatter types (\IntlDateFormatter::TRADITIONAL)?
             null
         );

--- a/src/FormBuilderBundle/Transformer/Output/FallbackTransformer.php
+++ b/src/FormBuilderBundle/Transformer/Output/FallbackTransformer.php
@@ -114,7 +114,7 @@ class FallbackTransformer implements OutputTransformerInterface
             $locale,
             $formatValues[$dateFormat],
             $formatValues[$timeFormat],
-            \IntlTimeZone::createTimeZone($value->getTimezone()->getName())->getID(),
+            $value->getTimezone() === false ? null : $value->getTimezone(),
             \IntlDateFormatter::GREGORIAN, // @todo: allow different formatter types (\IntlDateFormatter::TRADITIONAL)?
             null
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

This PR fixes the wrong time zone assignment, after a `DateTime` instance has been serialized.

### Without Serialization
The `DateTime` Instance gets parsed instantly, so a valid timezone is available:

![image](https://user-images.githubusercontent.com/700119/219677924-b1414d6d-119f-42a0-ad30-1aedef9e67cb.png)

With that, `\IntlTimeZone::createTimeZone` is able to create a valid timezone definition:

![image](https://user-images.githubusercontent.com/700119/219677826-9bbfa5fa-027c-47b6-9455-7344e6593325.png)


### With Serialization
The `DateTime` instance only returns the timezone offset:

![image](https://user-images.githubusercontent.com/700119/219678206-2b71492c-c700-4c8c-adf1-8960efbe5e7d.png)

With that, `\IntlTimeZone::createTimeZone` is not able to create a valid timezone definition:

![image](https://user-images.githubusercontent.com/700119/219678239-ff8120e2-5708-4004-9ef4-7bc4bba39277.png)

***
### Fix
Don't use the timezone name, but pass the timezone object directly, if given.