### PR TITLE
[email] Fix placeholder declaration in mail template

### DIFF
--- a/src/FormBuilderBundle/Resources/views/email/email.html.twig
+++ b/src/FormBuilderBundle/Resources/views/email/email.html.twig
@@ -11,7 +11,7 @@
         {% if editmode %}
 
             <div class="formbuilder-alert-info">
-                <strong>Admin:</strong> {{ 'form_builder.email.placeholder_list_available'|trans({},'admin')|format('<code>%Text(firstname);</code>')|raw }}
+                <strong>Admin:</strong> {{ 'form_builder.email.placeholder_list_available'|trans({},'admin')|format('<code>{{firstname}}</code>')|raw }}
             </div>
 
              {# If you're using output workflows, this property will be added on runtime and is not available in editmode! #}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Fixes wrong example for using placeholder(s) in email templates (`%Text(firstname);` -> `{{firstname}}`)
