### PR TITLE
 fix: Use less greedy placeholder regex to not match with pimcore native placeholders.

### DIFF
--- a/src/FormBuilderBundle/OutputWorkflow/Channel/Email/Parser/MailParser.php
+++ b/src/FormBuilderBundle/OutputWorkflow/Channel/Email/Parser/MailParser.php
@@ -152,7 +152,10 @@ class MailParser
         $realSubject = $mailTemplate->getSubject();
         $availableValues = $this->findPlaceholderValues($fieldValues);
 
-        preg_match_all('/\%(.+?)\%/', $realSubject, $matches);
+        // Find all _our_ placeholders but make sure not to match with pimcore
+        // placeholders like %Text(); or %DataObject(); by not allowing ; in the
+        // placeholder match.
+        preg_match_all('/\%([^;]+?)\%/', $realSubject, $matches);
 
         if (!isset($matches[1]) || count($matches[1]) === 0) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x for bug fixes
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | unlikely
| Deprecations? | no
| Fixed tickets | 

Fix for placeholder matching leading to unexpected replacements.
E.g. 
`%field_2052% %DataObject(user,{"method" : "getName"}); %DataObject(user,{"method" : "getFirstName"});` 
would be processed to: 
`MyFieldValue DataObject(user,{"method" : "getFirstName"});`

Because the regexp currently matches:
* %field_2052%
* %DataObject(user,{"method" : "getName"}); %

Disallowing `;` in the placeholder match should fix that while being more likely fully backward compatible than disallowing spaces or other chars. 
I consider it unlikely that someone has a `;` in a field name or in a somehow manually injected data entry.