### PR TITLE
suppress php warning of undefined array key

### DIFF
--- a/src/FormBuilderBundle/MailEditor/Widget/FormFieldWidget.php
+++ b/src/FormBuilderBundle/MailEditor/Widget/FormFieldWidget.php
@@ -41,7 +41,7 @@ class FormFieldWidget implements MailEditorWidgetInterface, MailEditorFieldDataW
     {
         $renderLabels = !isset($config['show_label']) || $config['show_label'] === true;
 
-        $outputData = $config['outputData'];
+        $outputData = $config['outputData'] ?? null;
         $fieldType = $outputData['field_type'] ?? null;
 
         if (!is_array($outputData)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master for features / 3.x for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->

PHP Warning "undefined array key" is thrown, when optional field is used in maileditor template.
