### PR TITLE
Adds min and max attribute values to the input field

### DIFF
--- a/src/FormBuilderBundle/EventSubscriber/FormBuilderSubscriber.php
+++ b/src/FormBuilderBundle/EventSubscriber/FormBuilderSubscriber.php
@@ -216,6 +216,10 @@ class FormBuilderSubscriber implements EventSubscriberInterface
 
             // add field constraints to data attribute since we need them for the frontend cl applier.
             foreach ($field->getConstraints() as $constraint) {
+                if (array_key_exists('config', $constraint) && $constraint['type'] === 'range') {
+                    $options['attr']['min'] = $constraint['config']['min'] ?? ($constraint['config']['minPropertyPath'] ?? null);
+                    $options['attr']['max'] = $constraint['config']['max'] ?? ($constraint['config']['maxPropertyPath'] ?? null);
+                }
                 $constraintNames[] = $constraint['type'];
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master for features
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #404 

This pr adds the min/max or min/maxPropertyPath values to the frontend input fields so that the browser only accepts appropirate input values
