### PR TITLE
Use name instead of ID in switchOutputWorkflow Action

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,7 @@
 - [DEPRECATION REMOVED] removed `FormDefinition::setMailLayout`. Please migrate to output workflows before updating
 - [IMPROVEMENT] Recommended folder structure by symfony adopted
 - [IMPROVEMENT] Make success flash message optional [#403](https://github.com/dachcom-digital/pimcore-formbuilder/issues/403)
+- [IMPROVEMENT] Use name instead of ID in output workflow actions [#408](https://github.com/dachcom-digital/pimcore-formbuilder/pull/408)
 - [FUNNEL] Route include changed from `@FormBuilderBundle/Resources/config/pimcore/routing_funnels.yml` to `@FormBuilderBundle/config/pimcore/routing_funnels.yaml`
 - [BC BREAK] Mail Layout Editor: While there is a migration, we're not able to migrate container (fieldset, repeater) fields. Please adjust your output workflow channels manually.
 - [BC BREAK] All views are lowercase/underscore now (`email/form_data.html.twig`, `form/elements/dynamic_multi_file/*`)

--- a/public/js/extjs/conditional-logic/action/switchOutputWorkflow.js
+++ b/public/js/extjs/conditional-logic/action/switchOutputWorkflow.js
@@ -22,12 +22,12 @@ Formbuilder.extjs.conditionalLogic.action.switchOutputWorkflow = Class.create(Fo
                 },
                 {
                     xtype: 'combo',
-                    name: _.generateFieldName(this.sectionId, this.index, 'workflowId'),
+                    name: _.generateFieldName(this.sectionId, this.index, 'workflowName'),
                     fieldLabel: t('form_builder_switch_output_workflow_identifier'),
                     anchor: '100%',
                     queryDelay: 0,
                     displayField: 'name',
-                    valueField: 'id',
+                    valueField: 'name',
                     mode: 'local',
                     labelAlign: 'top',
                     allowBlank: false,
@@ -50,7 +50,7 @@ Formbuilder.extjs.conditionalLogic.action.switchOutputWorkflow = Class.create(Fo
                         afterrender: function (cb) {
                             cb.store.load({
                                 callback: function () {
-                                    var value = this.data ? this.checkFieldAvailability([this.data.workflowId], cb.store, 'id') : null;
+                                    var value = this.data ? this.checkFieldAvailability([this.data.workflowName], cb.store, 'name') : null;
                                     cb.setValue(value !== null && value.length > 0 ? value[0] : null);
                                 }.bind(this)
                             });

--- a/public/js/extjs/conditional-logic/action/switchOutputWorkflow.js
+++ b/public/js/extjs/conditional-logic/action/switchOutputWorkflow.js
@@ -56,7 +56,7 @@ Formbuilder.extjs.conditionalLogic.action.switchOutputWorkflow = Class.create(Fo
                             });
                         }.bind(this),
                         updateIndexName: function (sectionId, index) {
-                            this.name = _.generateFieldName(sectionId, index, 'outputWorkflows');
+                            this.name = _.generateFieldName(sectionId, index, 'workflowName');
                         }
                     }
                 }

--- a/public/js/extjs/conditional-logic/condition/outputWorkflow.js
+++ b/public/js/extjs/conditional-logic/condition/outputWorkflow.js
@@ -25,7 +25,7 @@ Formbuilder.extjs.conditionalLogic.condition.outputWorkflow = Class.create(Formb
                     anchor: '100%',
                     stacked: true,
                     displayField: 'name',
-                    valueField: 'id',
+                    valueField: 'name',
                     allowBlank: false,
                     flex: 1,
                     queryMode: 'local',
@@ -49,7 +49,7 @@ Formbuilder.extjs.conditionalLogic.condition.outputWorkflow = Class.create(Formb
                         afterrender: function (cb) {
                             cb.store.load({
                                 callback: function () {
-                                    var value = this.data ? this.checkFieldAvailability(this.data.outputWorkflows, cb.store, 'id') : null;
+                                    var value = this.data ? this.checkFieldAvailability(this.data.outputWorkflows, cb.store, 'name') : null;
                                     cb.setValue(value);
                                 }.bind(this)
                             });

--- a/src/Controller/Admin/OutputWorkflowController.php
+++ b/src/Controller/Admin/OutputWorkflowController.php
@@ -184,6 +184,13 @@ class OutputWorkflowController extends AdminAbstractController
                     'message' => sprintf('Output Workflow with name "%s" already exists in this form!', $outputWorkflowName)
                 ]);
             }
+
+            if ($this->outputWorkflowManager->outputWorkflowIsRequiredByConditionalLogic($outputWorkflow)) {
+                return $this->json([
+                    'success' => false,
+                    'message' => sprintf('Output Workflow with name "%s" is required in conditional logic section. Please remove those dependencies first!', $outputWorkflowName)
+                ]);
+            }
         }
 
         $form = $this->formFactory->createNamed('', OutputWorkflowType::class, $outputWorkflow);
@@ -203,7 +210,7 @@ class OutputWorkflowController extends AdminAbstractController
             }
 
             $success = false;
-            $message = join('<br>', $errors);
+            $message = implode('<br>', $errors);
         }
 
         return $this->adminJson([

--- a/src/FormBuilderBundle/Migrations/Version20230908101855.php
+++ b/src/FormBuilderBundle/Migrations/Version20230908101855.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormBuilderBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230908101855 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace all workflowId fields with workflowName in switchWorkflow action';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $workflowIdMapData = $this->connection->fetchAllAssociative('SELECT id, name FROM formbuilder_output_workflow');
+
+        $workflowIdMap = array_reduce($workflowIdMapData, function ($carry, $data) {
+            $carry[$data['id']] = $data['name'];
+            return $carry;
+        }, []);
+        $forms = $this->connection->fetchAllAssociative("SELECT id, conditionalLogic FROM formbuilder_forms WHERE conditionalLogic LIKE '%switchOutputWorkflow%'");
+
+        foreach ($forms as $form) {
+            $conditionalLogic = array_map(static function ($logic) use($workflowIdMap) {
+                return [
+                    'condition' => $logic['condition'],
+                    'action' => array_map(static function ($action) use($workflowIdMap){
+                        if ($action['type'] !== 'switchOutputWorkflow') {
+                            return $action;
+                        }
+
+                        $action['workflowName'] = $workflowIdMap[$action['workflowId']];
+                        unset($action['workflowId']);
+                        return $action;
+
+                    }, $logic['action'])
+                ];
+            }, unserialize($form['conditionalLogic']));
+
+            $this->addSql('UPDATE formbuilder_forms SET conditionalLogic = ? WHERE id = ?', [serialize($conditionalLogic), $form['id']]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $workflowIdMapData = $this->connection->fetchAllAssociative('SELECT id, name FROM formbuilder_output_workflow');
+
+        $workflowIdMap = array_reduce($workflowIdMapData, function ($carry, $data) {
+            $carry[$data['name']] = $data['id'];
+            return $carry;
+        }, []);
+        $forms = $this->connection->fetchAllAssociative("SELECT id, conditionalLogic FROM formbuilder_forms WHERE conditionalLogic LIKE '%switchOutputWorkflow%'");
+
+        foreach ($forms as $form) {
+            $conditionalLogic = array_map(static function ($logic) use($workflowIdMap) {
+                return [
+                    'condition' => $logic['condition'],
+                    'action' => array_map(static function ($action) use($workflowIdMap){
+                        if ($action['type'] !== 'switchOutputWorkflow') {
+                            return $action;
+                        }
+
+                        $action['workflowId'] = $workflowIdMap[$action['workflowName']];
+                        unset($action['workflowName']);
+                        return $action;
+
+                    }, $logic['action'])
+                ];
+            }, unserialize($form['conditionalLogic']));
+
+            $this->addSql('UPDATE formbuilder_forms SET conditionalLogic = ? WHERE id = ?', [serialize($conditionalLogic), $form['id']]);
+        }
+    }
+}

--- a/src/Migrations/Version20230908101855.php
+++ b/src/Migrations/Version20230908101855.php
@@ -26,10 +26,22 @@ final class Version20230908101855 extends AbstractMigration
         $forms = $this->connection->fetchAllAssociative("SELECT id, conditionalLogic FROM formbuilder_forms WHERE conditionalLogic LIKE '%switchOutputWorkflow%'");
 
         foreach ($forms as $form) {
+
             $conditionalLogic = array_map(static function ($logic) use ($workflowIdMap) {
                 return [
-                    'condition' => $logic['condition'],
-                    'action'    => array_map(static function ($action) use ($workflowIdMap) {
+                    'condition' => array_map(static function ($condition) use ($workflowIdMap) {
+                        if ($condition['type'] !== 'outputWorkflow') {
+                            return $condition;
+                        }
+
+                        foreach ($condition['outputWorkflows'] as $index => $outputWorkflowId) {
+                            $condition['outputWorkflows'][$index] = $workflowIdMap[$outputWorkflowId];
+                        }
+
+                        return $condition;
+
+                    }, $logic['condition']),
+                    'action' => array_map(static function ($action) use ($workflowIdMap) {
                         if ($action['type'] !== 'switchOutputWorkflow') {
                             return $action;
                         }
@@ -61,7 +73,18 @@ final class Version20230908101855 extends AbstractMigration
         foreach ($forms as $form) {
             $conditionalLogic = array_map(static function ($logic) use ($workflowIdMap) {
                 return [
-                    'condition' => $logic['condition'],
+                    'condition' => array_map(static function ($condition) use ($workflowIdMap) {
+                        if ($condition['type'] !== 'outputWorkflow') {
+                            return $condition;
+                        }
+
+                        foreach ($condition['outputWorkflows'] as $index => $outputWorkflowId) {
+                            $condition['outputWorkflows'][$index] = $workflowIdMap[$outputWorkflowId];
+                        }
+
+                        return $condition;
+
+                    }, $logic['condition']),
                     'action'    => array_map(static function ($action) use ($workflowIdMap) {
                         if ($action['type'] !== 'switchOutputWorkflow') {
                             return $action;

--- a/src/Migrations/Version20230908101855.php
+++ b/src/Migrations/Version20230908101855.php
@@ -35,9 +35,6 @@ final class Version20230908101855 extends AbstractMigration
                                 return $condition;
                             }
 
-                            $condition['outputWorkflows'][0] = 21;
-                            $condition['outputWorkflows'][1] = 1;
-
                             foreach ($condition['outputWorkflows'] as $index => $outputWorkflowId) {
 
                                 if (!isset($workflowIdMap[$outputWorkflowId])) {
@@ -56,7 +53,7 @@ final class Version20230908101855 extends AbstractMigration
 
                             return $condition;
 
-                        }, $logic['condition'])
+                        }, $logic['condition'] ?? [])
                     ),
                     'action'    => array_filter(
                         array_map(static function ($action) use ($workflowIdMap) {
@@ -73,7 +70,7 @@ final class Version20230908101855 extends AbstractMigration
 
                             return $action;
 
-                        }, $logic['action'])
+                        }, $logic['action'] ?? [])
                     )
                 ];
             }, unserialize($form['conditionalLogic']));
@@ -94,6 +91,7 @@ final class Version20230908101855 extends AbstractMigration
         $forms = $this->connection->fetchAllAssociative("SELECT id, conditionalLogic FROM formbuilder_forms WHERE conditionalLogic LIKE '%switchOutputWorkflow%'");
 
         foreach ($forms as $form) {
+
             $conditionalLogic = array_map(static function ($logic) use ($workflowIdMap) {
                 return [
                     'condition' => array_map(static function ($condition) use ($workflowIdMap) {
@@ -107,7 +105,7 @@ final class Version20230908101855 extends AbstractMigration
 
                         return $condition;
 
-                    }, $logic['condition']),
+                    }, $logic['condition'] ?? []),
                     'action'    => array_map(static function ($action) use ($workflowIdMap) {
                         if ($action['type'] !== 'switchOutputWorkflow') {
                             return $action;
@@ -118,7 +116,7 @@ final class Version20230908101855 extends AbstractMigration
 
                         return $action;
 
-                    }, $logic['action'])
+                    }, $logic['action'] ?? [])
                 ];
             }, unserialize($form['conditionalLogic']));
 

--- a/src/Migrations/Version20230908101855.php
+++ b/src/Migrations/Version20230908101855.php
@@ -18,23 +18,25 @@ final class Version20230908101855 extends AbstractMigration
     {
         $workflowIdMapData = $this->connection->fetchAllAssociative('SELECT id, name FROM formbuilder_output_workflow');
 
-        $workflowIdMap = array_reduce($workflowIdMapData, function ($carry, $data) {
+        $workflowIdMap = array_reduce($workflowIdMapData, static function ($carry, $data) {
             $carry[$data['id']] = $data['name'];
             return $carry;
         }, []);
+
         $forms = $this->connection->fetchAllAssociative("SELECT id, conditionalLogic FROM formbuilder_forms WHERE conditionalLogic LIKE '%switchOutputWorkflow%'");
 
         foreach ($forms as $form) {
-            $conditionalLogic = array_map(static function ($logic) use($workflowIdMap) {
+            $conditionalLogic = array_map(static function ($logic) use ($workflowIdMap) {
                 return [
                     'condition' => $logic['condition'],
-                    'action' => array_map(static function ($action) use($workflowIdMap){
+                    'action'    => array_map(static function ($action) use ($workflowIdMap) {
                         if ($action['type'] !== 'switchOutputWorkflow') {
                             return $action;
                         }
 
                         $action['workflowName'] = $workflowIdMap[$action['workflowId']];
                         unset($action['workflowId']);
+
                         return $action;
 
                     }, $logic['action'])
@@ -49,23 +51,25 @@ final class Version20230908101855 extends AbstractMigration
     {
         $workflowIdMapData = $this->connection->fetchAllAssociative('SELECT id, name FROM formbuilder_output_workflow');
 
-        $workflowIdMap = array_reduce($workflowIdMapData, function ($carry, $data) {
+        $workflowIdMap = array_reduce($workflowIdMapData, static function ($carry, $data) {
             $carry[$data['name']] = $data['id'];
             return $carry;
         }, []);
+
         $forms = $this->connection->fetchAllAssociative("SELECT id, conditionalLogic FROM formbuilder_forms WHERE conditionalLogic LIKE '%switchOutputWorkflow%'");
 
         foreach ($forms as $form) {
-            $conditionalLogic = array_map(static function ($logic) use($workflowIdMap) {
+            $conditionalLogic = array_map(static function ($logic) use ($workflowIdMap) {
                 return [
                     'condition' => $logic['condition'],
-                    'action' => array_map(static function ($action) use($workflowIdMap){
+                    'action'    => array_map(static function ($action) use ($workflowIdMap) {
                         if ($action['type'] !== 'switchOutputWorkflow') {
                             return $action;
                         }
 
                         $action['workflowId'] = $workflowIdMap[$action['workflowName']];
                         unset($action['workflowName']);
+
                         return $action;
 
                     }, $logic['action'])

--- a/src/OutputWorkflow/OutputWorkflowResolver.php
+++ b/src/OutputWorkflow/OutputWorkflowResolver.php
@@ -29,8 +29,8 @@ class OutputWorkflowResolver implements OutputWorkflowResolverInterface
         /** @var SwitchOutputWorkflowData $switchOutputWorkflowData */
         $switchOutputWorkflowData = $this->checkOutputWorkflowCondition('switch_output_workflow', $data, $formRuntimeData, []);
 
-        if ($switchOutputWorkflowData->hasOutputWorkflowId()) {
-            $userSelectedOutputWorkflow = $switchOutputWorkflowData->getOutputWorkflowId();
+        if ($switchOutputWorkflowData->hasOutputWorkflowName()) {
+            $userSelectedOutputWorkflow = $switchOutputWorkflowData->getOutputWorkflowName();
         }
 
         $outputWorkflows = $formDefinition->getOutputWorkflows();
@@ -41,9 +41,7 @@ class OutputWorkflowResolver implements OutputWorkflowResolverInterface
 
         if ($userSelectedOutputWorkflow !== null) {
             $selectedOutputWorkflows = $outputWorkflows->filter(function (OutputWorkflowInterface $outputWorkflow) use ($userSelectedOutputWorkflow) {
-                return is_numeric($userSelectedOutputWorkflow)
-                    ? $outputWorkflow->getId() === $userSelectedOutputWorkflow
-                    : $outputWorkflow->getName() === $userSelectedOutputWorkflow;
+                return $outputWorkflow->getName() === $userSelectedOutputWorkflow;
             });
 
             return $selectedOutputWorkflows->count() === 1 ? $selectedOutputWorkflows->first() : null;

--- a/src/OutputWorkflow/OutputWorkflowResolver.php
+++ b/src/OutputWorkflow/OutputWorkflowResolver.php
@@ -41,7 +41,9 @@ class OutputWorkflowResolver implements OutputWorkflowResolverInterface
 
         if ($userSelectedOutputWorkflow !== null) {
             $selectedOutputWorkflows = $outputWorkflows->filter(function (OutputWorkflowInterface $outputWorkflow) use ($userSelectedOutputWorkflow) {
-                return $outputWorkflow->getName() === $userSelectedOutputWorkflow;
+                return is_numeric($userSelectedOutputWorkflow)
+                    ? $outputWorkflow->getId() === $userSelectedOutputWorkflow
+                    : $outputWorkflow->getName() === $userSelectedOutputWorkflow;
             });
 
             return $selectedOutputWorkflows->count() === 1 ? $selectedOutputWorkflows->first() : null;

--- a/src/Validation/ConditionalLogic/Dispatcher/Module/Data/SwitchOutputWorkflowData.php
+++ b/src/Validation/ConditionalLogic/Dispatcher/Module/Data/SwitchOutputWorkflowData.php
@@ -4,7 +4,7 @@ namespace FormBuilderBundle\Validation\ConditionalLogic\Dispatcher\Module\Data;
 
 class SwitchOutputWorkflowData implements DataInterface
 {
-    public const IDENTIFIER = 'workflowId';
+    public const IDENTIFIER = 'workflowName';
 
     private array $data = [];
 
@@ -23,14 +23,14 @@ class SwitchOutputWorkflowData implements DataInterface
         return $this->data;
     }
 
-    public function hasOutputWorkflowId(): bool
+    public function hasOutputWorkflowName(): bool
     {
-        return isset($this->data[self::IDENTIFIER]) && is_int($this->data[self::IDENTIFIER]);
+        return !empty($this->data[self::IDENTIFIER]);
     }
 
-    public function getOutputWorkflowId(): ?int
+    public function getOutputWorkflowName(): ?string
     {
-        if (!$this->hasOutputWorkflowId()) {
+        if (!$this->hasOutputWorkflowName()) {
             return null;
         }
 

--- a/src/Validation/ConditionalLogic/Dispatcher/Module/SwitchOutputWorkflow.php
+++ b/src/Validation/ConditionalLogic/Dispatcher/Module/SwitchOutputWorkflow.php
@@ -65,11 +65,11 @@ class SwitchOutputWorkflow implements ModuleInterface
                 continue;
             }
 
-            if (!isset($returnStackData['workflowId']) || !is_numeric($returnStackData['workflowId'])) {
+            if (empty($returnStackData['workflowName'])) {
                 continue;
             }
 
-            $switchWorkflowConfig['workflowId'] = (int) $returnStackData['workflowId'];
+            $switchWorkflowConfig['workflowName'] = $returnStackData['workflowName'];
         }
 
         $returnContainer->setData($switchWorkflowConfig);

--- a/src/Validation/ConditionalLogic/Rule/Action/SwitchOutputWorkflowAction.php
+++ b/src/Validation/ConditionalLogic/Rule/Action/SwitchOutputWorkflowAction.php
@@ -10,25 +10,25 @@ class SwitchOutputWorkflowAction implements ActionInterface
 {
     use ActionTrait;
 
-    protected ?string $workflowId = null;
+    protected ?string $workflowName = null;
 
     public function apply(bool $validationState, array $formData, int $ruleId): ReturnStackInterface
     {
         $data = [];
         if ($validationState === true) {
-            $data['workflowId'] = $this->getWorkflowId();
+            $data['workflowName'] = $this->getWorkflowName();
         }
 
         return new SimpleReturnStack('switchOutputWorkflow', $data);
     }
 
-    public function getWorkflowId(): ?string
+    public function getWorkflowName(): ?string
     {
-        return $this->workflowId;
+        return $this->workflowName;
     }
 
-    public function setWorkflowId(string $workflowId): void
+    public function setWorkflowName(string $workflowName): void
     {
-        $this->workflowId = $workflowId;
+        $this->workflowName = $workflowName;
     }
 }

--- a/src/Validation/ConditionalLogic/Rule/Condition/OutputWorkflowCondition.php
+++ b/src/Validation/ConditionalLogic/Rule/Condition/OutputWorkflowCondition.php
@@ -2,6 +2,8 @@
 
 namespace FormBuilderBundle\Validation\ConditionalLogic\Rule\Condition;
 
+use FormBuilderBundle\Model\OutputWorkflowInterface;
+use FormBuilderBundle\Repository\OutputWorkflowRepositoryInterface;
 use FormBuilderBundle\Validation\ConditionalLogic\Rule\Traits\ConditionTrait;
 
 class OutputWorkflowCondition implements ConditionInterface
@@ -9,6 +11,10 @@ class OutputWorkflowCondition implements ConditionInterface
     use ConditionTrait;
 
     protected array $outputWorkflow = [];
+
+    public function __construct(protected OutputWorkflowRepositoryInterface $outputWorkflowRepository)
+    {
+    }
 
     public function isValid(array $formData, int $ruleId, array $configuration = []): bool
     {
@@ -27,7 +33,14 @@ class OutputWorkflowCondition implements ConditionInterface
             return true;
         }
 
-        return in_array($configuration['formRuntimeOptions']['form_output_workflow'], $this->getOutputWorkflows(), true);
+        $formOutputWorkflowId = $configuration['formRuntimeOptions']['form_output_workflow'];
+        $outputWorkflow = $this->outputWorkflowRepository->findById($formOutputWorkflowId);
+
+        if (!$outputWorkflow instanceof OutputWorkflowInterface) {
+            return false;
+        }
+
+        return in_array($outputWorkflow->getName(), $this->getOutputWorkflows(), true);
     }
 
     public function getOutputWorkflows(): array

--- a/tests/Functional/ConditionalLogic/Action/Form/FormSwitchOutputWorkflowActionCest.php
+++ b/tests/Functional/ConditionalLogic/Action/Form/FormSwitchOutputWorkflowActionCest.php
@@ -41,7 +41,7 @@ class FormSwitchOutputWorkflowActionCest
         $actions = [
             [
                 'type'       => 'switchOutputWorkflow',
-                'workflowId' => $workflow->getId(),
+                'workflowName' => $workflow->getName(),
             ]
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->

The current implementation with referencing output workflows by ID in the conditional logic action breaks on export/import the form definition. 

I fixed this by referencing the output workflow by name instead.  