### PR TITLE
fix chunked upload

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,7 +1,8 @@
 # Upgrade Notes
  
 ## 5.0.4
-- Add Additional HrefTransformer validation for `$type` and `$id` [patkul0](https://github.com/dachcom-digital/pimcore-formbuilder/pull/434)
+- Add Additional HrefTransformer validation for `$type` and `$id` [@patkul0](https://github.com/dachcom-digital/pimcore-formbuilder/pull/434)
+- Fix chunked upload `$type` and `$id` [@life-style-de](https://github.com/dachcom-digital/pimcore-formbuilder/pull/430)
 
 ## 5.0.3
 - Fix element type check in api channel [#423](https://github.com/dachcom-digital/pimcore-formbuilder/issues/423)

--- a/src/Stream/FileStream.php
+++ b/src/Stream/FileStream.php
@@ -183,18 +183,13 @@ class FileStream implements FileStreamInterface
         $uuid = $mainRequest->request->get($options['uuid']);
         $fileSafeName = $this->getSafeFileName($options['fileName']);
 
-        $totalParts = $mainRequest->request->has($options['totalChunkCount']) ? (int) $mainRequest->request->get($options['totalChunkCount']) : 1;
-
         $tmpStream = tmpfile();
-        for ($i = 0; $i < $totalParts; $i++) {
+        $chunkFiles = $this->formBuilderChunkStorage->listContents($uuid);
 
-            $chunkFiles = $this->formBuilderChunkStorage->listContents($uuid);
-
-            foreach ($chunkFiles as $chunkFile) {
-                $chunkPathResource = $this->formBuilderChunkStorage->readStream($chunkFile->path());
-                stream_copy_to_stream($chunkPathResource, $tmpStream);
-                fclose($chunkPathResource);
-            }
+        foreach ($chunkFiles as $chunkFile) {
+            $chunkPathResource = $this->formBuilderChunkStorage->readStream($chunkFile->path());
+            stream_copy_to_stream($chunkPathResource, $tmpStream);
+            fclose($chunkPathResource);
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

assuming this commit/PR introduced the problem:
https://github.com/dachcom-digital/pimcore-formbuilder/commit/07ba2c3dc22bd8cc91803194428536bdb7097f8c 
https://github.com/dachcom-digital/pimcore-formbuilder/pull/374

the chunk handling was changed from getting the chunks by path+index to uuid based retrieval.

`$this->formBuilderChunkStorage->listContents($uuid)` already returns a full list of all chunks and the outer loop iterating additionally over all parts is not needed anymore. leading to all chunks being concatenated to the temp file `$totalParts` times. this results in a broken file that is `original_size * chunk_count` in size.