### PR TITLE
Fix: Additional HrefTransform validation for $type and $id

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
  
+## 5.0.4
+- Add Additional HrefTransformer validation for `$type` and `$id` #434 [patkul0](https://github.com/dachcom-digital/pimcore-formbuilder/pull/434)
+
 ## 5.0.3
 - Fix element type check in api channel [#423](https://github.com/dachcom-digital/pimcore-formbuilder/issues/423)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,7 +1,7 @@
 # Upgrade Notes
  
 ## 5.0.4
-- Add Additional HrefTransformer validation for `$type` and `$id` #434 [patkul0](https://github.com/dachcom-digital/pimcore-formbuilder/pull/434)
+- Add Additional HrefTransformer validation for `$type` and `$id` [patkul0](https://github.com/dachcom-digital/pimcore-formbuilder/pull/434)
 
 ## 5.0.3
 - Fix element type check in api channel [#423](https://github.com/dachcom-digital/pimcore-formbuilder/issues/423)

--- a/src/Transformer/HrefTransformer.php
+++ b/src/Transformer/HrefTransformer.php
@@ -28,6 +28,13 @@ class HrefTransformer implements OptionsTransformerInterface
             $type = $value['type'];
             $id = $value['id'];
 
+            if (
+                !in_array($type, ['object', 'asset', 'document'])
+                || empty($id)
+            ) {
+                continue;
+            }
+
             if (is_numeric($id)) {
                 $element = Service::getElementById($type, $id);
             } else {

--- a/src/Transformer/HrefTransformer.php
+++ b/src/Transformer/HrefTransformer.php
@@ -28,15 +28,12 @@ class HrefTransformer implements OptionsTransformerInterface
             $type = $value['type'];
             $id = $value['id'];
 
-            if (
-                !in_array($type, ['object', 'asset', 'document'])
-                || empty($id)
-            ) {
+            if (empty($id) || !in_array($type, ['object', 'asset', 'document'])) {
                 continue;
             }
 
             if (is_numeric($id)) {
-                $element = Service::getElementById($type, $id);
+                $element = Service::getElementById($type, (int) $id);
             } else {
                 // legacy
                 $element = Service::getElementByPath($type, $id);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

Add validation for `$type` and `$id` parameters because they are required by the Pimcore element service which has strict_types declaration. 

By default, FormBuilder sets these two parameters as null for empty languages. For example, because of that, the user was not able to load configuration that contains the `Snippet type` field.