### PR TITLE
fix type error in finishWithSuccess

### DIFF
--- a/src/OutputWorkflow/FormSubmissionFinisher.php
+++ b/src/OutputWorkflow/FormSubmissionFinisher.php
@@ -68,7 +68,7 @@ class FormSubmissionFinisher implements FormSubmissionFinisherInterface
             if ($e instanceof GuardOutputWorkflowException) {
                 $errorMessage = $e->getMessage();
             } elseif ($e instanceof GuardStackedException) {
-                $errorMessage = $e->getGuardExceptionMessages();
+                $errorMessage = implode(', ',$e->getGuardExceptionMessages());
             } else {
                 $errorMessage = sprintf('Error while dispatching workflow "%s". Message was: %s', $outputWorkflow->getName(), $e->getMessage());
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->

`GuardStackedException::getGuardExceptionMessages()` returns an array of messages, `$this->buildErrorResponse` only accepts strings as `$errorMessage`