### PR TITLE
Use TranslatorInterface instead of Pimcore Translator

### DIFF
--- a/src/FormBuilderBundle/Form/Type/DynamicMultiFile/DropZoneType.php
+++ b/src/FormBuilderBundle/Form/Type/DynamicMultiFile/DropZoneType.php
@@ -7,13 +7,13 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Pimcore\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DropZoneType extends AbstractType
 {
-    protected Translator $translator;
+    protected TranslatorInterface $translator;
 
-    public function __construct(Translator $translator)
+    public function __construct(TranslatorInterface $translator)
     {
         $this->translator = $translator;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

We have the Pimcore Translator decorated and this runs into the following issue then:

```
FormBuilderBundle\Form\Type\DynamicMultiFile\DropZoneType::__construct(): Argument #1 ($translator) must be of type Pimcore\Translation\Translator, App\Service\Translation given
```