### PR TITLE
Editor fix

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
  
+## 5.0.7
+- Remove `editable_root` restriction from mail editor
+
 ## 5.0.6
 - Fix magic property access [#442](https://github.com/dachcom-digital/pimcore-formbuilder/issues/442)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,7 @@
  
 ## 5.0.7
 - Remove `editable_root` restriction from mail editor
+- Skip widget field rendering, if no label and no value is available
 
 ## 5.0.6
 - Fix magic property access [#442](https://github.com/dachcom-digital/pimcore-formbuilder/issues/442)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,7 @@
 ## 5.0.7
 - Remove `editable_root` restriction from mail editor
 - Skip widget field rendering, if no label and no value is available
+- Use TranslatorInterface instead of Pimcore Translator [@dpfaffenbauer](https://github.com/dachcom-digital/pimcore-formbuilder/pull/446)
 
 ## 5.0.6
 - Fix magic property access [#442](https://github.com/dachcom-digital/pimcore-formbuilder/issues/442)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,7 @@
 - Remove `editable_root` restriction from mail editor
 - Skip widget field rendering, if no label and no value is available
 - Use TranslatorInterface instead of Pimcore Translator [@dpfaffenbauer](https://github.com/dachcom-digital/pimcore-formbuilder/pull/446)
+- fix type error in finishWithSuccess [@jheimbach](https://github.com/dachcom-digital/pimcore-formbuilder/pull/445)
 
 ## 5.0.6
 - Fix magic property access [#442](https://github.com/dachcom-digital/pimcore-formbuilder/issues/442)

--- a/public/js/extjs/extensions/formMailEditor.js
+++ b/public/js/extjs/extensions/formMailEditor.js
@@ -331,7 +331,6 @@ Formbuilder.extjs.extensions.formMailEditor = Class.create({
             plugins: type === 'html' ? 'code link lists table' : 'code',
             toolbar: type === 'html' ? 'bold italic | bullist numlist link | code | inserttable' : 'code',
             custom_elements: '~fb-field,fb-container-field',
-            editable_root: false,
             forced_root_block: 'div',
             contextmenu: false,
             object_resizing: false,

--- a/src/MailEditor/Widget/FormFieldWidget.php
+++ b/src/MailEditor/Widget/FormFieldWidget.php
@@ -76,6 +76,11 @@ class FormFieldWidget implements MailEditorWidgetInterface, MailEditorFieldDataW
     {
         $fieldValue = '';
         $label = $outputData['label'] ?? null;
+        $value = $outputData['value'] ?? null;
+
+        if ($label === null && $value === null) {
+            return '';
+        }
 
         if ($renderType === self::RENDER_TYPE_LABEL) {
             return !empty($label)
@@ -83,7 +88,7 @@ class FormFieldWidget implements MailEditorWidgetInterface, MailEditorFieldDataW
                 : '';
         }
 
-        $fieldValue .= $this->parseFieldValue($outputData['value'] ?? '[NO VALUE]');
+        $fieldValue .= $this->parseFieldValue($value ?? '[NO VALUE]');
 
         return $fieldValue;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #447 

Additional: Skip widget field rendering, if no label and no value is available
