### PR TITLE
fix min/max property field in RangeConstraint

### DIFF
--- a/public/js/extjs/components/formFieldConstraintComponent.js
+++ b/public/js/extjs/components/formFieldConstraintComponent.js
@@ -132,6 +132,7 @@ Formbuilder.extjs.components.formFieldConstraint = Class.create({
 
             switch (configElement.type) {
                 case 'string':
+                case 'mixed':
                     field = new Ext.form.TextField({
                         fieldLabel: configElement.name,
                         name: 'config.' + configElement.name,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #441   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
Constraint Range defines the type of min/max properties as 'mixed', this was not a switch case in `createBaseForm`