### PR TITLE
allow option configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ```json
 "require" : {
-    "dachcom-digital/formbuilder" : "~5.0.0"
+    "dachcom-digital/formbuilder" : "~5.1.0"
 }
 ```
 
@@ -52,6 +52,7 @@ Nothing to tell here, it's just [Symfony](https://symfony.com/doc/current/templa
 
 ## Further Information
 - [Usage (Rendering Types, Configuration)](docs/0_Usage.md)
+  - [Headless Mode](docs/1_HeadlessMode.md)
 - [SPAM Protection (Honeypot, reCAPTCHA)](docs/03_SpamProtection.md)
 - [Output Workflows](docs/OutputWorkflow/0_Usage.md)
   - [API Channel](docs/OutputWorkflow/09_ApiChannel.md)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,7 @@
 - **[SECURITY FEATURE]** Add [friendly captcha field](/docs/03_SpamProtection.md#friendly-captcha)
 - **[SECURITY FEATURE]** Add [cloudflare turnstile](/docs/03_SpamProtection.md#cloudflare-turnstile)
 - **[BUGFIX]** Use Pimcore AdminUserTranslator for Editable Dialog Box [#450](https://github.com/dachcom-digital/pimcore-formbuilder/issues/450)
+- **[IMPROVEMENT]** Improve json response success message behaviour [#416](https://github.com/dachcom-digital/pimcore-formbuilder/issues/416)
 - **[IMPROVEMENT]** [#458](https://github.com/dachcom-digital/pimcore-formbuilder/pull/458)
   - Allow to modify FormType options via `FORM_TYPE_OPTIONS` event
   - Do not render `formRuntimeDataToken` if csrf has been disabled in form options 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,9 @@
 - **[SECURITY FEATURE]** Add [friendly captcha field](/docs/03_SpamProtection.md#friendly-captcha)
 - **[SECURITY FEATURE]** Add [cloudflare turnstile](/docs/03_SpamProtection.md#cloudflare-turnstile)
 - **[BUGFIX]** Use Pimcore AdminUserTranslator for Editable Dialog Box [#450](https://github.com/dachcom-digital/pimcore-formbuilder/issues/450)
+- **[IMPROVEMENT]** [#458](https://github.com/dachcom-digital/pimcore-formbuilder/pull/458)
+  - Allow to modify FormType options via `FORM_TYPE_OPTIONS` event
+  - Do not render `formRuntimeDataToken` if csrf has been disabled in form options 
 
 ## 5.0.7
 - Remove `editable_root` restriction from mail editor

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,7 @@
   - Allow to modify FormType options via `FORM_TYPE_OPTIONS` event
   - Do not render `formRuntimeDataToken` if csrf has been disabled in form options 
   - Allow form assembling without request and view resolver
+  - Add FormDialogBuilder
 
 ## 5.0.7
 - Remove `editable_root` restriction from mail editor

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,7 @@
 - **[IMPROVEMENT]** [#458](https://github.com/dachcom-digital/pimcore-formbuilder/pull/458)
   - Allow to modify FormType options via `FORM_TYPE_OPTIONS` event
   - Do not render `formRuntimeDataToken` if csrf has been disabled in form options 
+  - Allow form assembling without request and view resolver
 
 ## 5.0.7
 - Remove `editable_root` restriction from mail editor

--- a/config/services/brick.yaml
+++ b/config/services/brick.yaml
@@ -5,9 +5,10 @@ services:
         autoconfigure: true
         public: true
 
-    # area brick
-    FormBuilderBundle\Document\Areabrick\Form\Form:
+    FormBuilderBundle\Document\Areabrick\Form\FormDialogBuilder:
         arguments:
             $translator: '@Pimcore\Bundle\AdminBundle\Translation\AdminUserTranslator'
+
+    FormBuilderBundle\Document\Areabrick\Form\Form:
         tags:
             - { name: pimcore.area.brick, id: formbuilder_form }

--- a/config/services/forms/forms.yaml
+++ b/config/services/forms/forms.yaml
@@ -35,6 +35,7 @@ services:
         arguments:
             - '@Symfony\Component\Form\FormFactoryInterface'
             - '@FormBuilderBundle\Configuration\Configuration'
+            - '@event_dispatcher'
             - '@FormBuilderBundle\Registry\DynamicMultiFileAdapterRegistry'
         tags:
             - { name: form.type }

--- a/docs/0_Usage.md
+++ b/docs/0_Usage.md
@@ -2,6 +2,11 @@
 There are **three** ways to render your form.
 > **Important:** It's possible to use multiple forms per page but **never** render the same form twice on the same page!
 
+## Headless Mode
+If you want to use FormBuilder in headless mode, please check out the documentation [here](./1_HeadlessMode.md).
+
+*** 
+
 ## Usage I. Area Brick
 This is the most used one. Just place a form element (Area Brick) somewhere on your document. 
 Configure it via the available edit button.
@@ -10,14 +15,14 @@ Configure it via the available edit button.
 Before we start, check out the available options. 
 Those are (only) needed for the twig and controller rendering type.
 
-| Name | Description |
-|------|-------------|
-| `form_id` | Can you guess it? It's the Form Id, right. |
-| `form_template` | Form Template, for example: `bootstrap_4_layout.html.twig` |
-| `main_layout` | This option is only needed if you render a form via a controller. By default, FormBuilder extends a empty default layout. If you want do extend your custom layout, define it: `layout.html.twig` |
-| `preset` | Optional: set a custom preset |
-| `custom_options` | Optional (array): Add some custom options as array here to pass them through the whole submission process (available in SubmissionEvent for example |
-| `output_workflow` | Define, which output workflow should get dispatched after a form has been successfully submitted. You could use the ID or Name of a output workflow |
+| Name              | Description                                                                                                                                                                                       |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `form_id`         | Can you guess it? It's the Form Id, right.                                                                                                                                                        |
+| `form_template`   | Form Template, for example: `bootstrap_4_layout.html.twig`                                                                                                                                        |
+| `main_layout`     | This option is only needed if you render a form via a controller. By default, FormBuilder extends a empty default layout. If you want do extend your custom layout, define it: `layout.html.twig` |
+| `preset`          | Optional: set a custom preset                                                                                                                                                                     |
+| `custom_options`  | Optional (array): Add some custom options as array here to pass them through the whole submission process (available in SubmissionEvent for example                                               |
+| `output_workflow` | Define, which output workflow should get dispatched after a form has been successfully submitted. You could use the ID or Name of a output workflow                                               |
 
 ## Usage II. Twig
 Create a Form using the Twig Extension.

--- a/docs/1_HeadlessMode.md
+++ b/docs/1_HeadlessMode.md
@@ -1,0 +1,61 @@
+# Headless Mode
+
+## AreaBrick
+You need to create your own editable, depending on your integration. You may want to use the `FormDialogBuilder` to simplify the area configuration section.
+
+## Form Building
+This is an example, how you may want to build FormBuilder forms in headless mode:
+
+```php
+$optionBuilder = new FormOptionsResolver();
+$optionBuilder->setFormId($formId);
+$optionBuilder->setFormTemplate($formTemplate);
+$optionBuilder->setFormPreset($formPreset);
+$optionBuilder->setOutputWorkflow($formOutputWorkflow);
+
+$form = $this->formAssembler->assembleHeadlessForm($optionBuilder);
+
+ $form->submit($request->request->all());
+
+if (!$form->isValid()) {
+
+    // process validation errors here
+    
+    return;
+}
+
+$response = null;
+$submissionEvent = new SubmissionEvent($request, $formRuntimeData, $form, null, false);
+$this->eventDispatcher->dispatch($submissionEvent, FormBuilderEvents::FORM_SUBMIT_SUCCESS);
+
+$finishResponse = $this->formSubmissionFinisher->finishWithSuccess($request, $submissionEvent);
+
+if ($finishResponse instanceof RedirectResponse) {
+    return [
+        'success'  => true,
+        'redirect' => $finishResponse->getTargetUrl()
+    ];
+}
+
+if ($finishResponse instanceof JsonResponse) {
+    $response = json_decode($finishResponse->getContent(), true, 512, JSON_THROW_ON_ERROR);
+}
+
+if ($response === null) {
+    throw new \InvalidArgumentException('empty success response');
+}
+
+if ($response['success'] === false) {
+
+    if (!array_key_exists('validation_errors', $response)) {
+        return $response;
+    }
+
+    $validationErrors = $response['validation_errors']
+    // process validation errors here
+    
+    return null;
+}
+
+return $response;
+```

--- a/docs/70_Events.md
+++ b/docs/70_Events.md
@@ -2,6 +2,23 @@
 
 It's possible to add some events to every form submission.
 
+## Form Type Options Event
+The `FORM_TYPE_OPTIONS` event is dispatched after the form builder options has been defined.
+It contains the field name, type and the defined options. You're able to modify the options only.
+
+@see \FormBuilderBundle\Event\Form\FormTypeOptionsEvent
+     
+**Example**  
+```php
+<?php
+
+use FormBuilderBundle\FormBuilderEvents;
+
+[
+    FormBuilderEvents::FORM_TYPE_OPTIONS => 'formTypeOptions'
+];
+```
+
 ## Pre Set Data Event
 The `FORM_PRE_SET_DATA` event is dispatched at the beginning of the Form::setData() method.
 It contains the form event and also some form builder settings.

--- a/src/Builder/FrontendFormBuilder.php
+++ b/src/Builder/FrontendFormBuilder.php
@@ -65,6 +65,7 @@ class FrontendFormBuilder
 
         $formOptions = [
             'csrf_protection' => $useCsrfProtection,
+            'action'          => $formDefinitionConfig['action'] === '/' ? $request->getUri() : $formDefinitionConfig['action'],
         ];
 
         $builder = $this->getBuilder($formDefinition, $formRuntimeData, $formAttributes, $formData, $formOptions);
@@ -83,8 +84,11 @@ class FrontendFormBuilder
         bool $useCsrfProtection = true
     ): FormInterface {
 
+        $formDefinitionConfig = $formDefinition->getConfiguration();
+
         $formOptions = [
             'csrf_protection'                => $useCsrfProtection,
+            'action'                         => $formDefinitionConfig['action'],
             'render_conditional_logic_field' => false,
             'render_form_id_field'           => false,
         ];
@@ -114,7 +118,6 @@ class FrontendFormBuilder
             $this->formDataFactory->createFormData($formDefinition, $formData),
             array_merge([
                 'method'            => $formDefinitionConfig['method'],
-                'action'            => $formDefinitionConfig['action'],
                 'current_form_id'   => $formDefinition->getId(),
                 'conditional_logic' => $formDefinition->getConditionalLogic(),
                 'runtime_data'      => $formRuntimeData,

--- a/src/Builder/FrontendFormBuilder.php
+++ b/src/Builder/FrontendFormBuilder.php
@@ -93,7 +93,7 @@ class FrontendFormBuilder
             'render_form_id_field'           => false,
         ];
 
-        $builder = $this->getBuilder($formDefinition, $formRuntimeData, $formAttributes, $formData, $formOptions, false);
+        $builder = $this->getBuilder($formDefinition, $formRuntimeData, $formAttributes, $formData, $formOptions, true);
 
         return $builder->getForm();
     }
@@ -104,7 +104,7 @@ class FrontendFormBuilder
         array $formAttributes,
         array $formData = [],
         array $formOptions = [],
-        bool $addFormName = true
+        bool $isHeadlessForm = false
     ): FormBuilderInterface {
 
         $formDefinitionConfig = $formDefinition->getConfiguration();
@@ -114,11 +114,12 @@ class FrontendFormBuilder
         }
 
         $builder = $this->formFactory->createNamedBuilder(
-            $addFormName === false ? '' : sprintf('formbuilder_%s', $formDefinition->getId()),
+            $isHeadlessForm === true ? '' : sprintf('formbuilder_%s', $formDefinition->getId()),
             DynamicFormType::class,
             $this->formDataFactory->createFormData($formDefinition, $formData),
             array_merge([
                 'method'            => $formDefinitionConfig['method'],
+                'is_headless_form'  => $isHeadlessForm,
                 'current_form_id'   => $formDefinition->getId(),
                 'conditional_logic' => $formDefinition->getConditionalLogic(),
                 'runtime_data'      => $formRuntimeData,

--- a/src/Builder/FrontendFormBuilder.php
+++ b/src/Builder/FrontendFormBuilder.php
@@ -93,7 +93,7 @@ class FrontendFormBuilder
             'render_form_id_field'           => false,
         ];
 
-        $builder = $this->getBuilder($formDefinition, $formRuntimeData, $formAttributes, $formData, $formOptions);
+        $builder = $this->getBuilder($formDefinition, $formRuntimeData, $formAttributes, $formData, $formOptions, false);
 
         return $builder->getForm();
     }
@@ -103,7 +103,8 @@ class FrontendFormBuilder
         array $formRuntimeData,
         array $formAttributes,
         array $formData = [],
-        array $formOptions = []
+        array $formOptions = [],
+        bool $addFormName = true
     ): FormBuilderInterface {
 
         $formDefinitionConfig = $formDefinition->getConfiguration();
@@ -113,7 +114,7 @@ class FrontendFormBuilder
         }
 
         $builder = $this->formFactory->createNamedBuilder(
-            sprintf('formbuilder_%s', $formDefinition->getId()),
+            $addFormName === false ? '' : sprintf('formbuilder_%s', $formDefinition->getId()),
             DynamicFormType::class,
             $this->formDataFactory->createFormData($formDefinition, $formData),
             array_merge([

--- a/src/Document/Areabrick/Form/Form.php
+++ b/src/Document/Areabrick/Form/Form.php
@@ -64,9 +64,9 @@ class Form extends AbstractAreabrick implements EditableDialogBoxInterface
         $outputWorkflowSelector = null;
 
         if ($info instanceof Document\Editable\Area\Info) {
-            /** @var Document\Editable\Select $formNameElement */
+            /** @var Document\Editable\Select $formSelector */
             $formSelector = $this->getDocumentEditable($info->getDocument(), 'select', 'formName');
-            /** @var Document\Editable\Select $outputWorkflowSelection */
+            /** @var Document\Editable\Select $outputWorkflowSelector */
             $outputWorkflowSelector = $this->getDocumentEditable($info->getDocument(), 'select', 'outputWorkflow');
         }
 

--- a/src/Document/Areabrick/Form/FormDialogBuilder.php
+++ b/src/Document/Areabrick/Form/FormDialogBuilder.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace FormBuilderBundle\Document\Areabrick\Form;
+
+use FormBuilderBundle\Model\OutputWorkflowInterface;
+use FormBuilderBundle\Manager\FormDefinitionManager;
+use FormBuilderBundle\Manager\TemplateManager;
+use FormBuilderBundle\Manager\PresetManager;
+use Pimcore\Extension\Document\Areabrick\EditableDialogBoxConfiguration;
+use Pimcore\Model\Document;
+use Pimcore\Model\Document\PageSnippet;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class FormDialogBuilder
+{
+    public function __construct(
+        protected FormDefinitionManager $formDefinitionManager,
+        protected PresetManager $presetManager,
+        protected TemplateManager $templateManager,
+        protected TranslatorInterface $translator
+    ) {
+    }
+
+    public function build(array $options): EditableDialogBoxConfiguration
+    {
+        $optionsResolver = new OptionsResolver();
+        $optionsResolver->setDefaults([
+            'add_preset_tab'                    => true,
+            'add_template_tab'                  => true,
+            'document'                          => null,
+            'form_selector_editable'            => null,
+            'output_workflow_selector_editable' => null,
+            'reload_on_close'                   => true,
+            'width'                             => 600,
+            'height'                            => 450
+        ]);
+
+        $optionsResolver->setAllowedTypes('document', ['null', PageSnippet::class]);
+        $optionsResolver->setAllowedTypes('form_selector_editable', ['null', Document\Editable\Select::class]);
+        $optionsResolver->setAllowedTypes('output_workflow_selector_editable', ['null', Document\Editable\Select::class]);
+        $optionsResolver->setAllowedTypes('add_preset_tab', ['bool']);
+        $optionsResolver->setAllowedTypes('add_template_tab', ['bool']);
+        $optionsResolver->setAllowedTypes('reload_on_close', ['bool']);
+        $optionsResolver->setAllowedTypes('width', ['integer']);
+        $optionsResolver->setAllowedTypes('height', ['integer']);
+
+        $options = $optionsResolver->resolve($options);
+
+        $editableDialog = new EditableDialogBoxConfiguration();
+
+        $formId = null;
+        $availableForms = [];
+        $formOutputWorkflows = [];
+        $validWorkflowIdsForCurrentSelection = [];
+
+        $allFormDefinitions = $this->formDefinitionManager->getAll();
+
+        if (!empty($allFormDefinitions)) {
+            foreach ($allFormDefinitions as $form) {
+                $availableForms[] = [$form->getId(), $form->getName()];
+                $formOutputWorkflows[$form->getId()] = array_map(static function (OutputWorkflowInterface $outputWorkflow) {
+                    return [$outputWorkflow->getId(), $outputWorkflow->getName()];
+                }, $form->getOutputWorkflows()->toArray());
+            }
+        }
+
+        $formSelectorEditable = $options['form_selector_editable'];
+        $outputWorkflowSelectorEditable = $options['output_workflow_selector_editable'];
+
+        if ($formSelectorEditable instanceof Document\Editable\Select && !$formSelectorEditable->isEmpty()) {
+            $formId = (int) $formSelectorEditable->getData();
+        }
+
+        $preSelectedOutputWorkflow = 'none';
+        $formOutputWorkflowStore = [['none', $this->translator->trans('form_builder.area.no_output_workflow', [], 'admin')]];
+
+        if ($formId !== null && isset($formOutputWorkflows[$formId]) && count($formOutputWorkflows[$formId]) > 0) {
+            $formOutputWorkflowStore = [];
+            foreach ($formOutputWorkflows[$formId] as $index => $outputWorkflow) {
+                if ($index === 0) {
+                    $preSelectedOutputWorkflow = $outputWorkflow[0];
+                }
+
+                $validWorkflowIdsForCurrentSelection[] = $outputWorkflow[0];
+                $formOutputWorkflowStore[] = [$outputWorkflow[0], $outputWorkflow[1]];
+            }
+        }
+
+        if (($outputWorkflowSelectorEditable instanceof Document\Editable\Select) && $outputWorkflowSelectorEditable->isEmpty() === false) {
+            $currentSelection = $outputWorkflowSelectorEditable->getData();
+            if (is_numeric($currentSelection) && !in_array((int) $currentSelection, $validWorkflowIdsForCurrentSelection, true)) {
+                $outputWorkflowSelectorEditable->setDataFromResource($preSelectedOutputWorkflow);
+            }
+        }
+
+        $tabbedItems = [];
+
+        $tabbedItems[] = [
+            'type'     => 'panel',
+            'title'    => $this->translator->trans('form_builder.area.tab.form', [], 'admin'),
+            'defaults' => [
+                'cls' => 'form-builder-panel'
+            ],
+            'items'    => [
+                [
+                    'type'   => 'select',
+                    'name'   => 'formName',
+                    'label'  => $this->translator->trans('form_builder.area.form', [], 'admin'),
+                    'config' => [
+                        'store'    => $availableForms,
+                        'width'    => 250,
+                        'onchange' => 'formBuilderAreaWatcher.watchOutputWorkflow.bind(this)'
+                    ]
+                ],
+                [
+                    'type'   => 'select',
+                    'name'   => 'outputWorkflow',
+                    'label'  => $this->translator->trans('form_builder.area.output_workflow', [], 'admin'),
+                    'config' => [
+                        'defaultValue' => $preSelectedOutputWorkflow,
+                        'width'        => 250,
+                        'store'        => $formOutputWorkflowStore,
+                        'class'        => 'fb-output-workflow-selector',
+                    ]
+                ]
+            ]
+        ];
+
+        if ($options['add_template_tab'] === true) {
+            $tabbedItems = $this->addTemplateTab($tabbedItems);
+        }
+
+        if ($options['add_preset_tab'] === true) {
+            $tabbedItems = $this->addPresetTab($tabbedItems, $options['document']);
+        }
+
+        $editableDialog->setReloadOnClose($options['reload_on_close']);
+        $editableDialog->setWidth($options['width']);
+        $editableDialog->setHeight($options['height']);
+
+        $editableDialog->setItems([
+            'type'  => 'tabpanel',
+            'items' => $tabbedItems
+        ]);
+
+        return $editableDialog;
+    }
+
+    protected function addTemplateTab(array $tabbedItems): array
+    {
+        $formTemplateStore = [];
+        foreach ($this->templateManager->getFormTemplates(true) as $template) {
+            $template[1] = $this->translator->trans($template[1], [], 'admin');
+            $formTemplateStore[] = $template;
+        }
+
+        $tabbedItems[] = [
+            'type'  => 'panel',
+            'title' => $this->translator->trans('form_builder.area.tab.template', [], 'admin'),
+            'items' => [
+                [
+                    'type'   => 'select',
+                    'name'   => 'formType',
+                    'label'  => $this->translator->trans('form_builder.area.form_template', [], 'admin'),
+                    'config' => [
+                        'defaultValue' => $this->templateManager->getDefaultFormTemplate(),
+                        'width'        => 250,
+                        'store'        => $formTemplateStore
+                    ]
+                ]
+            ]
+        ];
+
+        return $tabbedItems;
+    }
+
+    protected function addPresetTab(array $tabbedItems, Document\PageSnippet $baseDocument): array
+    {
+        $formPresetsStore = [];
+
+        $formPresets = $this->presetManager->getAll($baseDocument);
+
+        if (empty($formPresets)) {
+            return $tabbedItems;
+        }
+
+        $formPresetsStore[] = ['custom', $this->translator->trans('form_builder.area.no_form_preset', [], 'admin')];
+
+        foreach ($formPresets as $presetName => $preset) {
+            $formPresetsStore[] = [$presetName, $preset['nice_name']];
+        }
+
+        $tabbedItems[] = [
+            'type'  => 'panel',
+            'title' => $this->translator->trans('form_builder.area.tab.preset', [], 'admin'),
+            'items' => [
+                [
+                    'type'   => 'select',
+                    'name'   => 'formPreset',
+                    'label'  => $this->translator->trans('form_builder.area.form_preset', [], 'admin'),
+                    'config' => [
+                        'defaultValue' => 'custom',
+                        'width'        => 250,
+                        'store'        => $formPresetsStore,
+                        'onchange'     => 'formBuilderAreaWatcher.watchPresets.bind(this)'
+                    ]
+                ]
+            ]
+        ];
+
+        return $tabbedItems;
+    }
+}

--- a/src/Event/Form/FormTypeOptionsEvent.php
+++ b/src/Event/Form/FormTypeOptionsEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FormBuilderBundle\Event\Form;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class FormTypeOptionsEvent extends Event
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly ?string $type,
+        private array $options,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+}

--- a/src/Event/SubmissionEvent.php
+++ b/src/Event/SubmissionEvent.php
@@ -15,7 +15,9 @@ class SubmissionEvent extends Event
         private readonly Request $request,
         private readonly ?array $formRuntimeData,
         private readonly FormInterface $form,
-        protected ?array $funnelRuntimeData = null
+        private ?array $funnelRuntimeData = null,
+        private bool $useFlashBag = true,
+        private array $messages = []
     ) {
     }
 
@@ -64,4 +66,36 @@ class SubmissionEvent extends Event
         return $this->form;
     }
 
+    public function useFlashBag(): bool
+    {
+        return $this->useFlashBag;
+    }
+
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+
+    public function getMessagesOfType(string $type): array
+    {
+        return $this->messages[$type] ?? [];
+    }
+
+    public function hasMessagesOfType(string $type): bool
+    {
+        return array_key_exists($type, $this->messages);
+    }
+
+    public function addMessage(string $type, mixed $message): void
+    {
+        if (empty($message)) {
+            return;
+        }
+
+        if (!array_key_exists($type, $this->messages)) {
+            $this->messages[$type] = [];
+        }
+
+        $this->messages[$type][] = $message;
+    }
 }

--- a/src/Form/Type/DynamicFormType.php
+++ b/src/Form/Type/DynamicFormType.php
@@ -78,6 +78,10 @@ class DynamicFormType extends AbstractType
                 'data'   => $runtimeData,
             ]);
 
+        if ($options['csrf_protection'] === false) {
+            return;
+        }
+
         $builder
             ->add('formRuntimeDataToken', HiddenType::class, [
                 'mapped' => false,
@@ -85,6 +89,7 @@ class DynamicFormType extends AbstractType
             ]);
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+
             $data = $event->getData();
             $runtimeData = $data['formRuntimeData'] ?? null;
             $tokenValue = $data['formRuntimeDataToken'] ?? null;

--- a/src/Form/Type/DynamicFormType.php
+++ b/src/Form/Type/DynamicFormType.php
@@ -120,6 +120,7 @@ class DynamicFormType extends AbstractType
             'csrf_protection'                => true,
             'render_conditional_logic_field' => true,
             'render_form_id_field'           => true,
+            'is_headless_form'               => false,
             'data_class'                     => FormData::class
         ]);
     }

--- a/src/FormBuilderEvents.php
+++ b/src/FormBuilderEvents.php
@@ -5,6 +5,14 @@ namespace FormBuilderBundle;
 final class FormBuilderEvents
 {
     /**
+     * The FORM_TYPE_OPTIONS event is dispatched after the form builder options has been defined.
+     * It contains the field name, type and the defined options. You're able to modify the options only.
+     *
+     * @see \FormBuilderBundle\Event\Form\FormTypeOptionsEvent
+     */
+    public const FORM_TYPE_OPTIONS = 'form_builder.form_type.build_options';
+
+    /**
      * The FORM_PRE_SET_DATA event is dispatched at the beginning of the Form::setData() method.
      * It contains the form event and also some form builder settings.
      *

--- a/src/OutputWorkflow/FunnelWorker.php
+++ b/src/OutputWorkflow/FunnelWorker.php
@@ -261,6 +261,7 @@ class FunnelWorker implements FunnelWorkerInterface
         $form = $this->frontendFormBuilder->buildForm(
             $outputWorkflow->getFormDefinition(),
             $formRuntimeData,
+            [],
             $formData
         );
 

--- a/src/OutputWorkflow/SuccessManagementWorker.php
+++ b/src/OutputWorkflow/SuccessManagementWorker.php
@@ -4,7 +4,6 @@ namespace FormBuilderBundle\OutputWorkflow;
 
 use FormBuilderBundle\Event\SubmissionEvent;
 use FormBuilderBundle\Form\Data\FormDataInterface;
-use FormBuilderBundle\Session\FlashBagManagerInterface;
 use FormBuilderBundle\Tool\LocaleDataMapper;
 use FormBuilderBundle\Validation\ConditionalLogic\Dispatcher\Dispatcher;
 use FormBuilderBundle\Validation\ConditionalLogic\Dispatcher\Module\Data\DataInterface;
@@ -18,7 +17,6 @@ class SuccessManagementWorker implements SuccessManagementWorkerInterface
 {
     public function __construct(
         protected LocaleDataMapper $localeDataMapper,
-        protected FlashBagManagerInterface $flashBagManager,
         protected IncludeRenderer $includeRenderer,
         protected Dispatcher $dispatcher,
         protected TranslatorInterface $translator
@@ -35,7 +33,6 @@ class SuccessManagementWorker implements SuccessManagementWorkerInterface
         /** @var FormDataInterface $formData */
         $formData = $form->getData();
 
-        $formId = $formData->getFormDefinition()->getId();
         $error = false;
         $message = 'Success!';
 
@@ -44,8 +41,8 @@ class SuccessManagementWorker implements SuccessManagementWorkerInterface
 
         if ($successConditionData->hasData()) {
             $afterSuccess = $successConditionData->getIdentifiedData($locale);
-            if ($successConditionData->hasFlashMessage()) {
-                $this->flashBagManager->add('formbuilder_redirect_flash_message', $successConditionData->getFlashMessage($locale));
+            if ($submissionEvent->useFlashBag() === true && $successConditionData->hasFlashMessage()) {
+                $submissionEvent->addMessage('redirect_message', $successConditionData->getFlashMessage($locale));
             }
         } else {
             if ($successManagementConfiguration['identifier'] === 'string') {
@@ -70,14 +67,14 @@ class SuccessManagementWorker implements SuccessManagementWorkerInterface
                 $message = $e->getMessage();
             }
         } elseif ($afterSuccess instanceof Document) {
-            $message = $afterSuccess->getFullPath();
+            $message = null;
             $submissionEvent->setRedirectUri($afterSuccess->getFullPath());
-            if (!$this->flashBagManager->has('formbuilder_redirect_flash_message')) {
-                $redirectFlashMessage = isset($successManagementConfiguration['flashMessage'])
+            if (!$submissionEvent->hasMessagesOfType('redirect_message')) {
+                $redirectMessage = isset($successManagementConfiguration['flashMessage'])
                     ? $this->getFlashMessage($successManagementConfiguration['flashMessage'], $locale)
                     : null;
-                if (!is_null($redirectFlashMessage)) {
-                    $this->flashBagManager->add('formbuilder_redirect_flash_message', $redirectFlashMessage);
+                if (!is_null($redirectMessage)) {
+                    $submissionEvent->addMessage('redirect_message', $redirectMessage);
                 }
             }
         } elseif (is_string($afterSuccess)) {
@@ -89,9 +86,7 @@ class SuccessManagementWorker implements SuccessManagementWorkerInterface
             }
         }
 
-        $key = sprintf('formbuilder_%s_%s', $formId, ($error ? 'error' : 'success'));
-
-        $this->flashBagManager->add($key, $message);
+        $submissionEvent->addMessage($error ? 'error' : 'success', $message);
     }
 
     public function getSnippet(array $value, ?string $locale): ?Snippet

--- a/src/Resolver/FormOptionsResolver.php
+++ b/src/Resolver/FormOptionsResolver.php
@@ -10,7 +10,9 @@ class FormOptionsResolver
     protected ?string $formBlockTemplate = null;
     protected int|string|null $outputWorkflow = null;
     protected string $preset = 'custom';
+    protected bool $useCsrfProtection = true;
     protected array $customOptions = [];
+    protected array $formAttributes = [];
 
     public function setFormId(?int $formId): void
     {
@@ -58,6 +60,16 @@ class FormOptionsResolver
         return $this->preset;
     }
 
+    public function useCsrfProtection(): bool
+    {
+        return $this->useCsrfProtection;
+    }
+
+    public function setUseCsrfProtection(bool $useCsrfProtection): void
+    {
+        $this->useCsrfProtection = $useCsrfProtection;
+    }
+
     public function setCustomOptions(array $customOptions = []): void
     {
         $this->customOptions = $customOptions;
@@ -66,6 +78,16 @@ class FormOptionsResolver
     public function getCustomOptions(): array
     {
         return $this->customOptions;
+    }
+
+    public function getFormAttributes(): array
+    {
+        return $this->formAttributes;
+    }
+
+    public function setFormAttributes(array $formAttributes): void
+    {
+        $this->formAttributes = $formAttributes;
     }
 
     public function setFormTemplate(string $formTemplate): void

--- a/src/Session/FlashBagManagerInterface.php
+++ b/src/Session/FlashBagManagerInterface.php
@@ -6,19 +6,10 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 
 interface FlashBagManagerInterface
 {
-    /**
-     * Has flash messages for a given type?
-     */
     public function has(string $type): bool;
 
-    /**
-     * Adds a flash message for type
-     */
     public function add(string $type, mixed $message);
 
-    /**
-     * Gets and clears flash from the stack
-     */
     public function get(string $type, array $default = []): array;
 
     public function flashBagIsAvailable(): bool;

--- a/src/Twig/Extension/FlashMessageExtension.php
+++ b/src/Twig/Extension/FlashMessageExtension.php
@@ -28,7 +28,7 @@ class FlashMessageExtension extends AbstractExtension
         $messages = [];
         foreach ($types as $type) {
             $messages[$type] = [];
-            $messageKey = $formId . '_' . $type;
+            $messageKey = sprintf('formbuilder_%d_%s', $formId, $type);
 
             if (!$this->flashBagManager->has($messageKey)) {
                 continue;

--- a/src/Twig/Extension/FlashMessageExtension.php
+++ b/src/Twig/Extension/FlashMessageExtension.php
@@ -28,7 +28,7 @@ class FlashMessageExtension extends AbstractExtension
         $messages = [];
         foreach ($types as $type) {
             $messages[$type] = [];
-            $messageKey = sprintf('formbuilder_%d_%s', $formId, $type);
+            $messageKey = sprintf('%s_%s', $formId, $type);
 
             if (!$this->flashBagManager->has($messageKey)) {
                 continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

- Allow to modify FormType Options via `FORM_TYPE_OPTIONS` event
- Do not render `formRuntimeDataToken` if csrf has been disabled in form options
