### PR TITLE
fix migration and installer

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 5.1.1
+- **[BUGFIX]** Fix Migration and Installer
+
 ## 5.1.0
 - **[SECURITY FEATURE]** Double-Opt-In Feature, read more about it [here](./docs/04_DoubleOptIn.md)
 - **[SECURITY FEATURE]** Email Checker Validator [#471](https://github.com/dachcom-digital/pimcore-formbuilder/issues/471), read more about it [here](./docs/03_SpamProtection.md#email-checker)

--- a/src/Migrations/Version20240819150642.php
+++ b/src/Migrations/Version20240819150642.php
@@ -24,11 +24,16 @@ final class Version20240819150642 extends AbstractMigration implements Container
         $installer = $this->container->get(Install::class);
         $installer->updateTranslations();
 
-        $this->addSql('ALTER TABLE formbuilder_forms DROP mailLayout;');
+        if ($schema->getTable('formbuilder_forms')->hasColumn('mailLayout')) {
+            $this->addSql('ALTER TABLE formbuilder_forms DROP mailLayout;');
+        }
+
+        if ($schema->hasTable('formbuilder_double_opt_in_session')) {
+            return;
+        }
 
         $this->addSql('CREATE TABLE formbuilder_double_opt_in_session (token BINARY(16) NOT NULL COMMENT "(DC2Type:uuid)", form_definition INT DEFAULT NULL, email VARCHAR(190) NOT NULL, additional_data LONGTEXT DEFAULT NULL COMMENT "(DC2Type:array)", dispatch_location LONGTEXT DEFAULT NULL, applied TINYINT(1) DEFAULT 0 NOT NULL, creationDate DATETIME NOT NULL, INDEX IDX_88815C4F61F7634C (form_definition), INDEX token_form (token, form_definition, applied), UNIQUE INDEX email_form_definition (email, form_definition, applied), PRIMARY KEY(token)) DEFAULT CHARACTER SET UTF8MB4 COLLATE `utf8mb4_general_ci` ENGINE = InnoDB;');
         $this->addSql('ALTER TABLE formbuilder_double_opt_in_session ADD CONSTRAINT FK_88815C4F61F7634C FOREIGN KEY (form_definition) REFERENCES formbuilder_forms (id) ON DELETE CASCADE;');
-
     }
 
     public function down(Schema $schema): void

--- a/src/Tool/Install.php
+++ b/src/Tool/Install.php
@@ -2,6 +2,7 @@
 
 namespace FormBuilderBundle\Tool;
 
+use FormBuilderBundle\Migrations\Version20240819150642;
 use Pimcore\Extension\Bundle\Installer\Exception\InstallationException;
 use Pimcore\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
 use Pimcore\Model\Asset;
@@ -25,6 +26,11 @@ class Install extends SettingsStoreAwareInstaller
         $this->installDocumentTypes();
 
         parent::install();
+    }
+
+    public function getLastMigrationVersionClassName(): ?string
+    {
+        return Version20240819150642::class;
     }
 
     public function updateTranslations(): void

--- a/tests/_etc/config/app/config.yaml
+++ b/tests/_etc/config/app/config.yaml
@@ -14,7 +14,6 @@ doctrine:
     dbal:
         connections:
             default:
-                server_version: 8.0
                 mapping_types:
                     enum: string
                     bit: boolean

--- a/tests/_etc/config/app/config.yaml
+++ b/tests/_etc/config/app/config.yaml
@@ -14,6 +14,7 @@ doctrine:
     dbal:
         connections:
             default:
+                server_version: 8.0
                 mapping_types:
                     enum: string
                     bit: boolean


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #473

- Add latest migration to `getLastMigrationVersionClassName` to avoid additional migrations
- Check if column/table exists in migration