### PR TITLE
Fix DoubleOptInType Service Definition

### DIFF
--- a/config/services/forms/forms.yaml
+++ b/config/services/forms/forms.yaml
@@ -105,7 +105,7 @@ services:
     #
     # Double-Opt-In
 
-    FormBuilderBundle\Form\Type\DoubleOptIn\DoubleOptInType:
+    FormBuilderBundle\Form\Type\DoubleOptInType:
         public: false
         tags:
             - { name: form.type }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no0
| BC breaks?    | no
| Deprecations? | no

Service is defined wrong, `bin/console lint:container` throws an error, maybe add that command to the tests?
