### PR TITLE
Pimcore 12 Update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require": {
         "php": "^8.2",
-        "pimcore/pimcore": "^11.0",
+        "pimcore/pimcore": "^12.0",
         "symfony/form": "^6.4",
         "symfony/intl": "^6.4",
         "doctrine/orm": "^2.7 || ^3.0"

--- a/config/doctrine/model/DoubleOptInSession.orm.xml
+++ b/config/doctrine/model/DoubleOptInSession.orm.xml
@@ -11,7 +11,7 @@
             <custom-id-generator class="Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator"/>
         </id>
         <field name="email" type="string" column="email" length="190" nullable="false"/>
-        <field name="additionalData" type="array" column="additional_data" nullable="true"/>
+        <field name="additionalData" type="json" column="additional_data" nullable="true"/>
         <field name="dispatchLocation" type="text" column="dispatch_location" nullable="true"/>
         <field name="applied" type="boolean" column="applied">
             <options>

--- a/config/doctrine/model/FormDefinition.orm.xml
+++ b/config/doctrine/model/FormDefinition.orm.xml
@@ -12,8 +12,8 @@
         <field name="modificationDate" type="datetime" column="modificationDate" nullable="false"/>
         <field name="createdBy" type="integer" column="createdBy"/>
         <field name="modifiedBy" type="integer" column="modifiedBy"/>
-        <field name="configuration" type="object" column="configuration" nullable="true"/>
-        <field name="conditionalLogic" type="object" column="conditionalLogic" nullable="true"/>
+        <field name="configuration" type="json" column="configuration" nullable="true"/>
+        <field name="conditionalLogic" type="json" column="conditionalLogic" nullable="true"/>
         <field name="fields" type="form_builder_fields" column="fields" nullable="true"/>
         <one-to-many field="outputWorkflows" target-entity="FormBuilderBundle\Model\OutputWorkflow" mapped-by="formDefinition"
                      fetch="LAZY">

--- a/config/doctrine/model/OutputWorkflow.orm.xml
+++ b/config/doctrine/model/OutputWorkflow.orm.xml
@@ -11,7 +11,7 @@
         </id>
         <field name="name" type="string" column="`name`" length="190" nullable="true"/>
         <field name="funnelWorkflow" type="boolean" column="funnel_workflow" nullable="false"/>
-        <field name="successManagement" type="object" column="success_management" nullable="true"/>
+        <field name="successManagement" type="json" column="success_management" nullable="true"/>
         <one-to-many field="channels" target-entity="FormBuilderBundle\Model\OutputWorkflowChannel" mapped-by="outputWorkflow"
                      orphan-removal="true" fetch="LAZY">
             <cascade>

--- a/config/doctrine/model/OutputWorkflowChannel.orm.xml
+++ b/config/doctrine/model/OutputWorkflowChannel.orm.xml
@@ -11,8 +11,8 @@
         </id>
         <field name="type" type="string" column="type" length="190"/>
         <field name="name" type="string" column="name" length="190"/>
-        <field name="configuration" type="object" column="configuration" nullable="true"/>
-        <field name="funnelActions" type="object" column="funnel_actions" nullable="true"/>
+        <field name="configuration" type="json" column="configuration" nullable="true"/>
+        <field name="funnelActions" type="json" column="funnel_actions" nullable="true"/>
         <many-to-one field="outputWorkflow" target-entity="FormBuilderBundle\Model\OutputWorkflow" inversed-by="channels"
                      fetch="LAZY">
             <join-columns>

--- a/src/Form/Type/SnippetType.php
+++ b/src/Form/Type/SnippetType.php
@@ -56,7 +56,7 @@ class SnippetType extends AbstractType
         $view->vars = $vars;
     }
 
-    private function getSnippetId(array $data): ?string
+    private function getSnippetId(array $data): ?int
     {
         $locale = $this->requestStack->getMainRequest()->getLocale();
 

--- a/src/Migrations/Version20250911163105.php
+++ b/src/Migrations/Version20250911163105.php
@@ -53,14 +53,20 @@ class Version20250911163105 extends AbstractMigration implements ContainerAwareI
                 if (!empty($row[$column])) {
                     $unserialized = @unserialize($row[$column]);
                     if ($unserialized !== false) {
+                        // Successfully unserialized (could be empty array, object, etc.)
                         $updates[] = "$column = ?";
                         $values[] = json_encode($unserialized);
-                    } else {
-                        // If unserialization fails, store as JSON string
+                    } elseif ($row[$column] === '[]') {
+                        // Handle literal "[]" string as empty array
                         $updates[] = "$column = ?";
-                        $values[] = json_encode($row[$column]);
+                        $values[] = '[]';
+                    } elseif ($row[$column] === '{}') {
+                        // Handle literal "{}" string as empty object
+                        $updates[] = "$column = ?";
+                        $values[] = '{}';
                     }
                 } else {
+                    // Handle null and empty string cases
                     $updates[] = "$column = ?";
                     $values[] = null;
                 }

--- a/src/Migrations/Version20250911163105.php
+++ b/src/Migrations/Version20250911163105.php
@@ -23,6 +23,7 @@ class Version20250911163105 extends AbstractMigration implements ContainerAwareI
         $this->migrateTable($connection, 'formbuilder_forms', ['configuration', 'conditionalLogic']);
         $this->migrateTable($connection, 'formbuilder_output_workflow', ['success_management']);
         $this->migrateTable($connection, 'formbuilder_output_workflow_channel', ['configuration', 'funnel_actions']);
+        $this->migrateTable($connection, 'formbuilder_double_opt_in_session', ['additionalData']);
 
         // Change column types to JSON
         $this->addSql('ALTER TABLE formbuilder_forms MODIFY COLUMN configuration JSON');
@@ -30,6 +31,7 @@ class Version20250911163105 extends AbstractMigration implements ContainerAwareI
         $this->addSql('ALTER TABLE formbuilder_output_workflow MODIFY COLUMN success_management JSON');
         $this->addSql('ALTER TABLE formbuilder_output_workflow_channel MODIFY COLUMN configuration JSON');
         $this->addSql('ALTER TABLE formbuilder_output_workflow_channel MODIFY COLUMN funnel_actions JSON');
+        $this->addSql('ALTER TABLE formbuilder_double_opt_in_session MODIFY COLUMN additionalData JSON');
     }
 
     private function migrateTable($connection, $tableName, $columns): void

--- a/src/Migrations/Version20250911163105.php
+++ b/src/Migrations/Version20250911163105.php
@@ -23,7 +23,7 @@ class Version20250911163105 extends AbstractMigration implements ContainerAwareI
         $this->migrateTable($connection, 'formbuilder_forms', ['configuration', 'conditionalLogic']);
         $this->migrateTable($connection, 'formbuilder_output_workflow', ['success_management']);
         $this->migrateTable($connection, 'formbuilder_output_workflow_channel', ['configuration', 'funnel_actions']);
-        $this->migrateTable($connection, 'formbuilder_double_opt_in_session', ['additionalData']);
+        $this->migrateTable($connection, 'formbuilder_double_opt_in_session', ['additional_data']);
 
         // Change column types to JSON
         $this->addSql('ALTER TABLE formbuilder_forms MODIFY COLUMN configuration JSON');

--- a/src/Migrations/Version20250911163105.php
+++ b/src/Migrations/Version20250911163105.php
@@ -20,13 +20,8 @@ class Version20250911163105 extends AbstractMigration implements ContainerAwareI
     {
         $connection = $this->connection;
 
-        // 1. Migrate formbuilder_forms table
         $this->migrateTable($connection, 'formbuilder_forms', ['configuration', 'conditionalLogic']);
-
-        // 2. Migrate formbuilder_output_workflow table
         $this->migrateTable($connection, 'formbuilder_output_workflow', ['success_management']);
-
-        // 3. Migrate formbuilder_output_workflow_channel table
         $this->migrateTable($connection, 'formbuilder_output_workflow_channel', ['configuration', 'funnel_actions']);
 
         // Change column types to JSON
@@ -53,20 +48,16 @@ class Version20250911163105 extends AbstractMigration implements ContainerAwareI
                 if (!empty($row[$column])) {
                     $unserialized = @unserialize($row[$column]);
                     if ($unserialized !== false) {
-                        // Successfully unserialized (could be empty array, object, etc.)
                         $updates[] = "$column = ?";
                         $values[] = json_encode($unserialized);
                     } elseif ($row[$column] === '[]') {
-                        // Handle literal "[]" string as empty array
                         $updates[] = "$column = ?";
                         $values[] = '[]';
                     } elseif ($row[$column] === '{}') {
-                        // Handle literal "{}" string as empty object
                         $updates[] = "$column = ?";
                         $values[] = '{}';
                     }
                 } else {
-                    // Handle null and empty string cases
                     $updates[] = "$column = ?";
                     $values[] = null;
                 }
@@ -84,7 +75,7 @@ class Version20250911163105 extends AbstractMigration implements ContainerAwareI
 
     public function down(Schema $schema): void
     {
-        // This migration is not reversible as we're converting serialized data to JSON
+        // This migration is not reversible because we are converting serialized data to JSON
         $this->throwIrreversibleMigrationException();
     }
 }

--- a/src/Migrations/Version20250911163105.php
+++ b/src/Migrations/Version20250911163105.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace FormBuilderBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class Version20250911163105 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getDescription(): string
+    {
+        return 'Migrate formbuilder_forms.configuration and formbuilder_forms.conditionalLogic data from object to json format';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // First migrate the data
+        $this->addSql("
+            UPDATE formbuilder_forms
+            SET configuration = CASE
+                WHEN configuration IS NOT NULL AND configuration != ''
+                THEN JSON_QUOTE(configuration)
+                ELSE NULL
+            END,
+            conditionalLogic = CASE
+                WHEN conditionalLogic IS NOT NULL AND conditionalLogic != ''
+                THEN JSON_QUOTE(conditionalLogic)
+                ELSE NULL
+            END;
+        ");
+
+        // Then change the column types
+        $table = $schema->getTable('formbuilder_forms');
+
+        if ($table->hasColumn('configuration')) {
+            $table->changeColumn('configuration', [
+                'type' => \Doctrine\DBAL\Types\Types::JSON,
+                'notnull' => false,
+                'comment' => null
+            ]);
+        }
+
+        if ($table->hasColumn('conditionalLogic')) {
+            $table->changeColumn('conditionalLogic', [
+                'type' => \Doctrine\DBAL\Types\Types::JSON,
+                'notnull' => false,
+                'comment' => null
+            ]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // This migration is not reversible as we're converting serialized data to JSON
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes

Updates the bundle to be compatible with Pimcore 12 (Classic Admin UI).
Because `type="object"` is deprecated in Doctrine we have to migrate the existing columns to JSON.


/cc @solverat as mentioned [here](https://github.com/dachcom-digital/pimcore-formbuilder/discussions/520#discussioncomment-14295736), I'm not sure how you want to handle the license change